### PR TITLE
feat: add version command

### DIFF
--- a/bin/__tests__/carbon-codemod.js
+++ b/bin/__tests__/carbon-codemod.js
@@ -21,6 +21,7 @@ const chalk = require("chalk");
 const fs = require("fs");
 const path = require("path");
 const Cli = require("../cli");
+const packageJSON = require("../../package.json");
 
 describe("run", () => {
   beforeAll(() => {
@@ -28,6 +29,21 @@ describe("run", () => {
   });
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it("displays the version", () => {
+    let spy = jest.spyOn(process.stdout, "write");
+    process.argv = [
+      "/Users/jamime/.nvm/versions/node/v10.16.3/bin/node",
+      "/Users/jamime/.nvm/versions/node/v10.16.3/bin/carbon-codemod",
+      "--version"
+    ];
+
+    new Cli().run();
+
+    expect(execaSync).not.toBeCalled();
+    expect(process.stdout.write).toBeCalledWith(`${packageJSON.version}\n`);
+    spy.mockRestore();
   });
 
   it("displays help if no arguments are passed", () => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,7 @@ const chalk = require("chalk");
 const commander = require("commander");
 const execa = require("execa");
 const jsCodeShiftBin = require.resolve(".bin/jscodeshift");
+const packageJSON = require("../package.json");
 
 const checkGitStatus = (force = false) => {
   let clean;
@@ -71,6 +72,7 @@ const runTransform = (program, transformer, target) => {
 function Cli() {
   const program = new commander.Command();
   program
+    .version(packageJSON.version)
     .option("--force", "skip safety checks")
     .option("--dry", "dry run (no changes are made to files)")
     .command("button-destructive <target>")


### PR DESCRIPTION
### Proposed behaviour
Add the version command which will display the version from `package.json`.

```sh
npx carbon-codemod --version
```
<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Current behaviour

It's not possible to see what version of the codemod is running.

<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Readme updated

### Additional context
https://github.com/tj/commander.js#version-option
<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- `git checkout`
- `node ./bin/carbon-codemod.js --version`
