### PR TITLE
fix(button-destructive): initialise destructive value in spread objects

### DIFF
--- a/transforms/button-destructive/__testfixtures__/Spread.output.js
+++ b/transforms/button-destructive/__testfixtures__/Spread.output.js
@@ -1,7 +1,7 @@
 import Button from "carbon-react/lib/components/button";
 const props = {
   buttonType: "primary",
-  destructive,
+  destructive: true,
   onClick: () => {}
 };
 const buttonType = "primary";
@@ -9,16 +9,16 @@ const type = "primary";
 export default () => <Button {...props} />;
 export const one = () => <Button {...{
   buttonType: "primary",
-  destructive,
+  destructive: true,
   onClick: () => {}
 }} />;
 export const two = () => <Button {...{
   buttonType,
-  destructive,
+  destructive: true,
   onClick: () => {}
 }} />;
 export const three = () => <Button {...{
   buttonType: type,
-  destructive,
+  destructive: true,
   onClick: () => {}
 }} />;

--- a/transforms/button-destructive/__testfixtures__/SpreadOverride.output.js
+++ b/transforms/button-destructive/__testfixtures__/SpreadOverride.output.js
@@ -1,6 +1,6 @@
 import Button from "carbon-react/lib/components/button";
 const props = {
   buttonType: "primary",
-  destructive
+  destructive: true
 }
 export default () => <Button buttonType="primary" {...props} />

--- a/transforms/button-destructive/button-destructive.js
+++ b/transforms/button-destructive/button-destructive.js
@@ -99,8 +99,7 @@ function transformer(fileInfo, api, options) {
         j.property.from({
           kind: "init",
           key: j.identifier("destructive"),
-          value: j.identifier("destructive"),
-          shorthand: true
+          value: j.literal(true)
         })
       );
       return true;
@@ -134,8 +133,7 @@ function transformer(fileInfo, api, options) {
           j.property.from({
             kind: "init",
             key: j.identifier("destructive"),
-            value: j.identifier("destructive"),
-            shorthand: true
+            value: j.literal(true)
           })
         );
         return true;
@@ -204,8 +202,7 @@ function transformer(fileInfo, api, options) {
           j.property.from({
             kind: "init",
             key: j.identifier("destructive"),
-            value: j.identifier("destructive"),
-            shorthand: true
+            value: j.literal(true)
           })
         );
         didUpdate = true;


### PR DESCRIPTION
### Proposed behaviour

<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
When spreading an object we should initialise the destructive value.
```diff
{
  buttonType: 'primary'
- destructive
+ destructive: true
}
```

### Current behaviour
We spread the object which has a shorthand destructive prop, but it does not reference a value and will throw a Syntax Error.
```js
const props = {
  buttonType: 'primary'
  destructive
}
...
<Button {...props} />
```
<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
<del>- [ ] Readme updated

### Additional context

https://github.com/Sage/carbon-codemod/tree/master/transforms/button-destructive

### Testing instructions

See changes to tests and check TravisCI.
You can also run the codemod if you check it out locally.

<!-- How can a reviewer test this PR? -->
