### PR TITLE
feat: replace create with button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vscode
+coverage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ The release notes of `carbon-react` will indicate which codemod you should use.
 npx carbon-codemod <name-of-codemod> <target>
 ```
 
-- [`button-destructive`](https://github.com/Sage/carbon-codemod/tree/master/transforms/button-destructive)
+- [`button-destructive`](./transforms/button-destructive)
+- [`deprecate-create`](./transforms/deprecate-create)
+
+Note that `<target>` is worked out relative to the current working directory.
 
 ## Development
 
@@ -20,11 +23,11 @@ npx carbon-codemod <name-of-codemod> <target>
 - `npm link`
 - `cd my-other-project`
 - `npm link carbon-codemod`
-- `npx carbon-codemod`
+- `npx carbon-codemod <name-of-codemod> <target>`
 
 ### Debugging
 
-- `node --debug-brk ./bin/carbon-codemod`
+- `node --inspect-brk ./bin/carbon-codemod`
 
 You can use [astexplorer.net](https://astexplorer.net/) to help understand the existing structure of files. You should use the following settings:
 

--- a/bin/__tests__/carbon-codemod.js
+++ b/bin/__tests__/carbon-codemod.js
@@ -177,5 +177,30 @@ describe("run", () => {
       expect(execaSync.mock.calls[1][0]).toEqual(Cli.__jsCodeShiftBin);
       expect(execaSync.mock.calls[1][1]).toEqual(args);
     });
+
+    it("runs deprecate-create", () => {
+      process.argv = [
+        "/Users/jamime/.nvm/versions/node/v10.16.3/bin/node",
+        "/Users/jamime/.nvm/versions/node/v10.16.3/bin/carbon-codemod",
+        "deprecate-create",
+        "src",
+      ];
+
+      new Cli().run();
+      const args = [
+        "--verbose=2",
+        "--ignore-pattern=**/node_modules/**",
+        "--transform",
+        path.join(
+          Cli.__transformsDir,
+          "deprecate-create",
+          "deprecate-create.js"
+        ),
+        path.join(process.cwd(), "src"),
+      ];
+      expect(console.log).toBeCalledWith(`jscodeshift ${args.join(" ")}`);
+      expect(execaSync.mock.calls[1][0]).toEqual(Cli.__jsCodeShiftBin);
+      expect(execaSync.mock.calls[1][1]).toEqual(args);
+    });
   });
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -74,12 +74,19 @@ function Cli() {
   program
     .version(packageJSON.version)
     .option("--force", "skip safety checks")
-    .option("--dry", "dry run (no changes are made to files)")
+    .option("--dry", "dry run (no changes are made to files)");
+
+  program
     .command("button-destructive <target>")
     .description(
       "Convert destructive buttons to primary buttons with a destructive prop"
     )
     .action(runTransform.bind(undefined, program, "button-destructive"));
+
+  program
+    .command("deprecate-create <target>")
+    .description("Convert create to dashed fullwidth button")
+    .action(runTransform.bind(undefined, program, "deprecate-create"));
 
   program.on("command:*", function () {
     console.error(

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  collectCoverage: true,
+  coverageReporters: ["html", "text"],
+};

--- a/transforms/deprecate-create/README.md
+++ b/transforms/deprecate-create/README.md
@@ -1,0 +1,35 @@
+# deprecate-create
+
+The `Create` component has been deprecated in favour of full width `Button`'s. This codemod will convert usages of the `Create` component to a `Button`.
+
+```diff
+- import Create from "carbon-react/lib/components/create";
++ import Button from "carbon-react/lib/components/button";
+
+- <Create>Resource name</Create>
++ <Button buttonType=“dashed” iconType=“plus” iconPosition=“after” fullWidth>Resource name</Button>
+```
+
+This codemod accounts for the following patterns. Note that any existing props on `Create` will be maintained. If a `Button` import already exists in a file, a new one will not be added.
+
+```js
+<Create />;
+```
+
+```js
+<Create className="test-class" onClick={callback} />
+```
+
+```js
+<Create>Resource Name</Create>;
+```
+
+```js
+<Create className="test-class" onClick={() => undefined}>Resource Name</Create>
+```
+
+If there is a pattern that you use that is not covered here, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod deprecate-create <target>`

--- a/transforms/deprecate-create/__testfixtures__/Basic.input.js
+++ b/transforms/deprecate-create/__testfixtures__/Basic.input.js
@@ -1,0 +1,3 @@
+import Create from "carbon-react/lib/components/create";
+export default () => <Create />;
+export const withProps = () => <Create className="test-class" onClick={() => undefined} />;

--- a/transforms/deprecate-create/__testfixtures__/Basic.output.js
+++ b/transforms/deprecate-create/__testfixtures__/Basic.output.js
@@ -1,0 +1,9 @@
+import Button from "carbon-react/lib/components/button";
+export default () => <Button buttonType="dashed" iconType="plus" iconPosition="after" fullWidth />;
+export const withProps = () => <Button
+  className="test-class"
+  onClick={() => undefined}
+  buttonType="dashed"
+  iconType="plus"
+  iconPosition="after"
+  fullWidth />;

--- a/transforms/deprecate-create/__testfixtures__/CreateAndButton.input.js
+++ b/transforms/deprecate-create/__testfixtures__/CreateAndButton.input.js
@@ -1,0 +1,9 @@
+import Button from "carbon-react/lib/components/button";
+import Create from "carbon-react/lib/components/create";
+export default () => 
+(
+  <>
+    <Button />
+    <Create />
+  </>
+);

--- a/transforms/deprecate-create/__testfixtures__/CreateAndButton.output.js
+++ b/transforms/deprecate-create/__testfixtures__/CreateAndButton.output.js
@@ -1,0 +1,8 @@
+import Button from "carbon-react/lib/components/button";
+export default () => 
+(
+  <>
+    <Button />
+    <Button buttonType="dashed" iconType="plus" iconPosition="after" fullWidth />
+  </>
+);

--- a/transforms/deprecate-create/__testfixtures__/HasChildren.input.js
+++ b/transforms/deprecate-create/__testfixtures__/HasChildren.input.js
@@ -1,0 +1,3 @@
+import Create from "carbon-react/lib/components/create";
+export default () => <Create>Resource Name</Create>;
+export const withProps = () => <Create className="test-class" onClick={() => undefined}>Resource Name</Create>;

--- a/transforms/deprecate-create/__testfixtures__/HasChildren.output.js
+++ b/transforms/deprecate-create/__testfixtures__/HasChildren.output.js
@@ -1,0 +1,9 @@
+import Button from "carbon-react/lib/components/button";
+export default () => <Button buttonType="dashed" iconType="plus" iconPosition="after" fullWidth>Resource Name</Button>;
+export const withProps = () => <Button
+  className="test-class"
+  onClick={() => undefined}
+  buttonType="dashed"
+  iconType="plus"
+  iconPosition="after"
+  fullWidth>Resource Name</Button>;

--- a/transforms/deprecate-create/__testfixtures__/NoImport.input.js
+++ b/transforms/deprecate-create/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Wrong Import
+import Create from "carbon-react/lib/components/NotCreate";
+export default () => <Create />;

--- a/transforms/deprecate-create/__tests__/deprecate-create-test.js
+++ b/transforms/deprecate-create/__tests__/deprecate-create-test.js
@@ -1,0 +1,6 @@
+import defineTest from "../../../defineTest";
+
+defineTest(__dirname, "deprecate-create", null, "Basic");
+defineTest(__dirname, "deprecate-create", null, "CreateAndButton");
+defineTest(__dirname, "deprecate-create", null, "HasChildren");
+defineTest(__dirname, "deprecate-create", null, "NoImport");

--- a/transforms/deprecate-create/deprecate-create.js
+++ b/transforms/deprecate-create/deprecate-create.js
@@ -1,0 +1,132 @@
+/*
+ * Convert all <Create /> to
+ * <Button buttonType=“dashed” iconType=“plus” iconPosition=“after” fullWidth />
+ */
+import registerMethods from "../registerMethods";
+
+function transformer(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  registerMethods(j);
+
+  /*
+    Change import from 'import Create from "carbon-react/lib/components/create";'
+    to 'import Button from "carbon-react/lib/components/button";'
+  */
+  const ImportReplacement = () => {
+    const createImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: "carbon-react/lib/components/create",
+      },
+    });
+
+    const buttonImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: "carbon-react/lib/components/button",
+      },
+    });
+
+    // If there's already a Button import, just remove the Create one
+    if (buttonImport.size()) {
+      createImport.remove();
+      return true;
+    }
+
+    createImport.replaceWith(
+      j.importDeclaration(
+        [j.importDefaultSpecifier(j.identifier("Button"))],
+        j.literal("carbon-react/lib/components/button")
+      )
+    );
+    return true;
+  };
+
+  const OpeningTagReplacement = (tag) => {
+    // Change the tag from Create to Button
+    const name = tag.find(j.JSXIdentifier, { name: "Create" });
+    if (name.size()) {
+      // If there's already attributes, add the new ones after
+      const currentAttributes = tag.find(j.JSXAttribute);
+
+      let props = [
+        ...currentAttributes.nodes(),
+        j.jsxAttribute(j.jsxIdentifier("buttonType"), j.literal("dashed")),
+        j.jsxAttribute(j.jsxIdentifier("iconType"), j.literal("plus")),
+        j.jsxAttribute(j.jsxIdentifier("iconPosition"), j.literal("after")),
+        j.jsxAttribute(j.jsxIdentifier("fullWidth")),
+      ];
+
+      const selfClosing = tag.nodes()[0].selfClosing;
+      tag.replaceWith(
+        j.jsxOpeningElement(j.jsxIdentifier("Button"), props, selfClosing)
+      );
+      return true;
+    }
+  };
+
+  const ClosingTagReplacement = (tag) => {
+    // Change the tag from Create to Button
+    const name = tag.find(j.JSXIdentifier, { name: "Create" });
+
+    if (name.size()) {
+      name.replaceWith(j.jsxIdentifier("Button"));
+      return true;
+    }
+  };
+
+  const JSXElementReplacement = (create) => {
+    // Opening tag
+    const createOpeningTags = create.find(j.JSXOpeningElement, {
+      name: {
+        type: "JSXIdentifier",
+        name: "Create",
+      },
+    });
+
+    // Closing tag. If it doesn't exist, the opening tag is self closing
+    const createClosingTags = create.find(j.JSXClosingElement, {
+      name: {
+        type: "JSXIdentifier",
+        name: "Create",
+      },
+    });
+
+    let tagsReplaced = OpeningTagReplacement(createOpeningTags.last());
+
+    if (createClosingTags.size()) {
+      const closingTag = createClosingTags.last();
+      tagsReplaced = tagsReplaced && ClosingTagReplacement(closingTag);
+    }
+
+    return tagsReplaced;
+  };
+
+  const root = j(fileInfo.source);
+
+  const creates = root.findJSXElementsByImport(
+    "carbon-react/lib/components/create"
+  );
+
+  if (creates.size() === 0) {
+    // If the component is not imported, skip this file
+    return;
+  }
+
+  let didUpdateFile = false;
+
+  creates.forEach((path) => {
+    const create = j(path);
+    const didImportReplacement = ImportReplacement();
+    const didElementReplacement = JSXElementReplacement(create);
+
+    let didConvertCreate = didImportReplacement && didElementReplacement;
+    didUpdateFile = didUpdateFile ? true : didConvertCreate;
+  });
+
+  if (didUpdateFile) {
+    return root.toSource();
+  }
+}
+
+module.exports = transformer;


### PR DESCRIPTION
### Proposed behaviour

This PR adds in a new transform to replace the deprecated `Create` component with the `Button` component.

### Current behaviour

This functionality does not currently exist.

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

### Additional context

### Testing instructions

Follow the instructions on the readme and run the codemod over a test repository
