### PR TITLE
feat: add universal replace-prop and remove-prop codemods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npx carbon-codemod <name-of-codemod> <target>
 - [`button-destructive`](./transforms/button-destructive)
 - [`deprecate-create`](./transforms/deprecate-create)
 - [`message-remove-classic-theme`](./transforms/message-remove-classic-theme)
+- [`rename-prop`](./transforms/rename-prop)
+- [`remove-prop`](./transforms/remove-prop)
 
 Note that `<target>` is worked out relative to the current working directory.
 

--- a/bin/__tests__/carbon-codemod.js
+++ b/bin/__tests__/carbon-codemod.js
@@ -13,7 +13,7 @@ const execaSync = jest.fn((bin) => {
 jest.setMock("execa", {
   sync: execaSync,
 });
-const noop = () => { };
+const noop = () => {};
 jest.spyOn(console, "log").mockImplementation(noop);
 jest.spyOn(process, "exit").mockImplementation(noop);
 
@@ -222,6 +222,58 @@ describe("run", () => {
           "message-remove-classic-theme.js"
         ),
         path.join(process.cwd(), "src"),
+      ];
+      expect(console.log).toBeCalledWith(`jscodeshift ${args.join(" ")}`);
+      expect(execaSync.mock.calls[1][0]).toEqual(Cli.__jsCodeShiftBin);
+      expect(execaSync.mock.calls[1][1]).toEqual(args);
+    });
+
+    it("runs rename-prop", () => {
+      process.argv = [
+        "/Users/guest/.nvm/versions/node/v10.16.3/bin/node",
+        "/Users/guest/.nvm/versions/node/v10.16.3/bin/carbon-codemod",
+        "rename-prop",
+        "src",
+        "carbon-react/lib/components/button",
+        "buttonType",
+        "variant",
+      ];
+
+      new Cli().run();
+      const args = [
+        "--verbose=2",
+        "--ignore-pattern=**/node_modules/**",
+        "--transform",
+        path.join(Cli.__transformsDir, "rename-prop", "rename-prop.js"),
+        path.join(process.cwd(), "src"),
+        "--component=carbon-react/lib/components/button",
+        "--old=buttonType",
+        "--replacement=variant",
+      ];
+      expect(console.log).toBeCalledWith(`jscodeshift ${args.join(" ")}`);
+      expect(execaSync.mock.calls[1][0]).toEqual(Cli.__jsCodeShiftBin);
+      expect(execaSync.mock.calls[1][1]).toEqual(args);
+    });
+
+    it("runs remove-prop", () => {
+      process.argv = [
+        "/Users/guest/.nvm/versions/node/v10.16.3/bin/node",
+        "/Users/guest/.nvm/versions/node/v10.16.3/bin/carbon-codemod",
+        "remove-prop",
+        "src",
+        "carbon-react/lib/components/button",
+        "buttonType",
+      ];
+
+      new Cli().run();
+      const args = [
+        "--verbose=2",
+        "--ignore-pattern=**/node_modules/**",
+        "--transform",
+        path.join(Cli.__transformsDir, "remove-prop", "remove-prop.js"),
+        path.join(process.cwd(), "src"),
+        "--component=carbon-react/lib/components/button",
+        "--prop=buttonType",
       ];
       expect(console.log).toBeCalledWith(`jscodeshift ${args.join(" ")}`);
       expect(execaSync.mock.calls[1][0]).toEqual(Cli.__jsCodeShiftBin);

--- a/transforms/remove-prop/README.md
+++ b/transforms/remove-prop/README.md
@@ -1,0 +1,56 @@
+# remove-prop
+
+This universal codemod provides possibility to remove any prop from any component
+
+```diff
+- <Component old="info" />
++ <Component />
+```
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Component old="old" />
+```
+
+```js
+<Component old={"old"} />
+```
+
+```js
+<Component old={old} />
+```
+
+```js
+<Component {...props} />
+```
+
+```js
+<Component {...{ old: "old" }} />
+```
+
+```js
+<Component {...{ old }} />
+```
+
+```js
+<Component {...{ old: oldType }} />
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod remove-prop <target> <component-import-path> <prop>`
+
+### Example
+
+`npx carbon-codemod remove-prop src carbon-react/lib/components/button buttonType`
+
+```js
+import Button from "carbon-react/lib/components/button";
+```
+```diff
+- <Button buttonType="primary>Button</Button>
++ <Button>Button</Button>
+```

--- a/transforms/remove-prop/__testfixtures__/Basic.input.js
+++ b/transforms/remove-prop/__testfixtures__/Basic.input.js
@@ -1,0 +1,10 @@
+import Component from "carbon-react/lib/components/component";
+export default () => <Component prop="info" />;
+export const withProps = () => <Component prop="info" title="Example" />;
+const prop = "info";
+export const asVariable = () => <Component prop={prop} />;
+const props = { prop: "info", title: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "info", title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, title: "Example" }} />;

--- a/transforms/remove-prop/__testfixtures__/Basic.output.js
+++ b/transforms/remove-prop/__testfixtures__/Basic.output.js
@@ -1,0 +1,18 @@
+import Component from "carbon-react/lib/components/component";
+export default () => <Component />;
+export const withProps = () => <Component title="Example" />;
+const prop = "info";
+export const asVariable = () => <Component />;
+const props = {
+  title: "Example"
+}
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{
+  title: "Example"
+}} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{
+  title: "Example"
+}} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{
+  title: "Example"
+}} />;

--- a/transforms/remove-prop/__testfixtures__/Bug.input.js
+++ b/transforms/remove-prop/__testfixtures__/Bug.input.js
@@ -1,0 +1,3 @@
+import Component from "carbon-react/lib/components/component";
+export default ({ ...props }) => <Component prop="info" {...props}>Example</Component>;
+export const ExampleTwo = ({ prop, ...props }) => <Component prop={prop} {...props}>Example</Component>;

--- a/transforms/remove-prop/__testfixtures__/Bug.output.js
+++ b/transforms/remove-prop/__testfixtures__/Bug.output.js
@@ -1,0 +1,3 @@
+import Component from "carbon-react/lib/components/component";
+export default ({ ...props }) => <Component {...props}>Example</Component>;
+export const ExampleTwo = ({ prop, ...props }) => <Component {...props}>Example</Component>;

--- a/transforms/remove-prop/__testfixtures__/NoImport.input.js
+++ b/transforms/remove-prop/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Wrong Import
+import Component from "carbon-react/lib/components/NotComponent";
+export default () => <Component />;

--- a/transforms/remove-prop/__tests__/remove-prop.js
+++ b/transforms/remove-prop/__tests__/remove-prop.js
@@ -1,0 +1,31 @@
+import defineTest from "../../../defineTest";
+
+defineTest(
+  __dirname,
+  "remove-prop",
+  {
+    component: "carbon-react/lib/components/component",
+    prop: "prop",
+  },
+  "Basic"
+);
+
+defineTest(
+  __dirname,
+  "remove-prop",
+  {
+    component: "carbon-react/lib/components/component",
+    prop: "prop",
+  },
+  "Bug"
+);
+
+defineTest(
+  __dirname,
+  "remove-prop",
+  {
+    component: "carbon-react/lib/components/component",
+    prop: "prop",
+  },
+  "NoImport"
+);

--- a/transforms/remove-prop/remove-prop.js
+++ b/transforms/remove-prop/remove-prop.js
@@ -1,0 +1,27 @@
+/*
+ * Convert all <Component old="" /> to <Component />
+ */
+import { removeAttribute } from "../builder";
+import registerMethods from "../registerMethods";
+
+const transformer = (fileInfo, api, options) => {
+  const j = api.jscodeshift;
+  registerMethods(j);
+  const root = j(fileInfo.source);
+
+  const { component, prop } = options;
+
+  const result = removeAttribute(component, prop)(
+    fileInfo,
+    api,
+    options,
+    j,
+    root
+  );
+
+  if (result) {
+    return root.toSource();
+  }
+};
+
+module.exports = transformer;

--- a/transforms/rename-prop/README.md
+++ b/transforms/rename-prop/README.md
@@ -1,0 +1,56 @@
+# rename-prop
+
+This universal codemod provides possibility to replace any prop with a new one in any component
+
+```diff
+- <Component old="info" />
++ <Component new="info" />
+```
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Component old="old" />
+```
+
+```js
+<Component old={"old"} />
+```
+
+```js
+<Component old={old} />
+```
+
+```js
+<Component {...props} />
+```
+
+```js
+<Component {...{ old: "old" }} />
+```
+
+```js
+<Component {...{ old }} />
+```
+
+```js
+<Component {...{ old: oldType }} />
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod rename-prop <target> <component-import-path> <old-prop> <new-prop>`
+
+### Example
+
+`npx carbon-codemod rename-prop src carbon-react/lib/components/button buttonType variant`
+
+```js
+import Button from "carbon-react/lib/components/button";
+```
+```diff
+- <Button buttonType="primary>Button</Button>
++ <Button variant="primary">Button</Button>
+```

--- a/transforms/rename-prop/__testfixtures__/Basic.input.js
+++ b/transforms/rename-prop/__testfixtures__/Basic.input.js
@@ -1,0 +1,10 @@
+import Component from "carbon-react/lib/components/component";
+export default () => <Component old="info" />;
+export const withProps = () => <Component old="info" title="Example" />;
+const old = "info";
+export const asVariable = () => <Component old={old} />;
+const props = { old: "info", title: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ old: "info", title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ old, title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ old: old, title: "Example" }} />;

--- a/transforms/rename-prop/__testfixtures__/Basic.output.js
+++ b/transforms/rename-prop/__testfixtures__/Basic.output.js
@@ -1,0 +1,10 @@
+import Component from "carbon-react/lib/components/component";
+export default () => <Component replacement="info" />;
+export const withProps = () => <Component replacement="info" title="Example" />;
+const old = "info";
+export const asVariable = () => <Component replacement={old} />;
+const props = { replacement: "info", title: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ replacement: "info", title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ replacement: old, title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ replacement: old, title: "Example" }} />;

--- a/transforms/rename-prop/__testfixtures__/Bug.input.js
+++ b/transforms/rename-prop/__testfixtures__/Bug.input.js
@@ -1,0 +1,3 @@
+import Component from "carbon-react/lib/components/component";
+export default ({ ...props }) => <Component old="info" {...props}>Example</Component>;
+export const ExampleTwo = ({ old, ...props }) => <Component old={old} {...props}>Example</Component>;

--- a/transforms/rename-prop/__testfixtures__/Bug.output.js
+++ b/transforms/rename-prop/__testfixtures__/Bug.output.js
@@ -1,0 +1,3 @@
+import Component from "carbon-react/lib/components/component";
+export default ({ ...props }) => <Component replacement="info" {...props}>Example</Component>;
+export const ExampleTwo = ({ old, ...props }) => <Component replacement={old} {...props}>Example</Component>;

--- a/transforms/rename-prop/__testfixtures__/NoImport.input.js
+++ b/transforms/rename-prop/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Wrong Import
+import Component from "carbon-react/lib/components/NotComponent";
+export default () => <Component />;

--- a/transforms/rename-prop/__tests__/rename-prop.js
+++ b/transforms/rename-prop/__tests__/rename-prop.js
@@ -1,0 +1,34 @@
+import defineTest from "../../../defineTest";
+
+defineTest(
+  __dirname,
+  "rename-prop",
+  {
+    component: "carbon-react/lib/components/component",
+    old: "old",
+    replacement: "replacement",
+  },
+  "Basic"
+);
+
+defineTest(
+  __dirname,
+  "rename-prop",
+  {
+    component: "carbon-react/lib/components/component",
+    old: "old",
+    replacement: "replacement",
+  },
+  "Bug"
+);
+
+defineTest(
+  __dirname,
+  "rename-prop",
+  {
+    component: "carbon-react/lib/components/component",
+    old: "old",
+    replacement: "replacement",
+  },
+  "NoImport"
+);

--- a/transforms/rename-prop/rename-prop.js
+++ b/transforms/rename-prop/rename-prop.js
@@ -1,0 +1,27 @@
+/*
+ * Convert all <Component old="" /> to <Component new="" />
+ */
+import { renameAttribute } from "../builder";
+import registerMethods from "../registerMethods";
+
+const transformer = (fileInfo, api, options) => {
+  const j = api.jscodeshift;
+  registerMethods(j);
+  const root = j(fileInfo.source);
+
+  const { component, old, replacement } = options;
+
+  const result = renameAttribute(component, old, replacement)(
+    fileInfo,
+    api,
+    options,
+    j,
+    root
+  );
+
+  if (result) {
+    return root.toSource();
+  }
+};
+
+module.exports = transformer;


### PR DESCRIPTION
### Proposed behaviour

This PR adds two universal codemods `replace-prop` and `remove-prop`. These can be used on any Component / prop name combination.

#### rename-prop

Usage

`npx carbon-codemod rename-prop <target> <component-import-path> <old-prop> <new-prop>`

`npx carbon-codemod rename-prop src carbon-react/lib/components/component old new`

```diff
- <Component old="info" />
+ <Component new="info" />
```

#### remove-prop

Usage

`npx carbon-codemod remove-prop <target> <component-import-path> <prop>`

`npx carbon-codemod remove-prop src carbon-react/lib/components/component prop`

```diff
- <Component prop="info" />
+ <Component />
```

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

