### PR TITLE
feat: tile padding prop codemod

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ npx carbon-codemod <name-of-codemod> <target>
 - [`message-remove-classic-theme`](./transforms/message-remove-classic-theme)
 - [`rename-prop`](./transforms/rename-prop)
 - [`remove-prop`](./transforms/remove-prop)
+- [`replace-prop-value`](./transforms/replace-prop-value)
+- [`tile-update-padding-prop`](./transforms/tile-update-padding-prop)
 
 Note that `<target>` is worked out relative to the current working directory.
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,6 +107,13 @@ function Cli() {
     .action((target, command) => runTransform(target, command, program));
 
   program
+    .command("tile-update-padding-prop <target>")
+    .description(
+      "Replace padding prop with p prop and change values on tile component"
+    )
+    .action((target, command) => runTransform(target, command, program));
+
+  program
     .command("rename-prop <target> <component> <old> <replacement>")
     .description(
       `
@@ -145,6 +152,35 @@ Example
     )
     .action((target, component, prop, command) =>
       runTransform(target, command, program, { component, prop })
+    );
+
+  program
+    .command(
+      "replace-prop-value <target> <component> <prop> <oldValue> <newValue>"
+    )
+    .description(
+      `
+Codemod used for prop value changing
+Usage
+  npx carbon-codemod replace-prop-value <target> <component> <prop> <oldValue> <newValue>
+
+  target       Files or directory to transform
+  component    Import path of component which prop should be renamed
+  prop         Prop name
+  oldValue     Prop value to change
+  newValue     Value to change prop to
+
+Example
+  npx carbon-codemod replace-prop-value src carbon-react/lib/components/component prop oldValue newValue
+    `
+    )
+    .action((target, component, attribute, oldValue, newValue, command) =>
+      runTransform(target, command, program, {
+        component,
+        attribute,
+        oldValue,
+        newValue,
+      })
     );
 
   program.on("command:*", function () {

--- a/transforms/builder/finder.js
+++ b/transforms/builder/finder.js
@@ -1,109 +1,72 @@
-import registerMethods from "./registerMethods";
-
-const run = (...transformers) => {
-  return function rootTransformer(fileInfo, api, options) {
-    let didReplacement = false;
-    const j = api.jscodeshift;
-    registerMethods(j);
-    const root = j(fileInfo.source);
-
-    transformers.forEach((transformer) => {
-      const result = transformer(fileInfo, api, options, j, root);
-      didReplacement = didReplacement || result;
-    });
-
-    if (didReplacement) {
-      return root.toSource();
-    }
-  };
-};
-
 /**
  * Rename a component prop
  * @param {string} path the component import path
- * @param {string} old prop name to replace
+ * @param {string} prop prop name to operate on
  * @param {string} replacement new prop name
  */
-const renameAttribute = (path, old, replacement) => (
-  fileInfo,
-  api,
-  options,
-  j,
-  root
-) => {
+const finder = (
+  path,
+  prop,
+  {
+    JSXAttributeReplacement: JSXAttributeReplacementFn,
+    ObjectExpressionsLiteralReplacement: ObjectExpressionsLiteralReplacementFn,
+    ObjectExpressionsIdentifierReplacement: ObjectExpressionsIdentifierReplacementFn,
+    JSXSpreadAttributeIdentifierReplacement: JSXSpreadAttributeIdentifierReplacementFn,
+  }
+) => (fileInfo, api, options, j, root) => {
   /*
    * <Component prop="" />
    */
-  const JSXAttributeReplacement = (message) => {
-    let didReplacement = false;
-    const attributes = message.find(j.JSXAttribute, {
+  const JSXAttributeReplacement = (component) => {
+    const attributes = component.find(j.JSXAttribute, {
       name: {
         type: "JSXIdentifier",
-        name: old,
+        name: prop,
       },
     });
 
-    if (replacement) {
-      attributes.forEach((nodePath) => {
-        nodePath.node.name = replacement;
-        didReplacement = true;
-      });
-    } else if (attributes.size()) {
-      attributes.remove();
-      didReplacement = true;
+    if (attributes.size()) {
+      return JSXAttributeReplacementFn(attributes, j);
     }
-
-    return didReplacement;
   };
 
   /*
-   * <Component {...{old: 'info'}} />
-   * <Component {...{old: old}} />
+   * <Component {...{prop: 'info'}} />
+   * <Component {...{prop: prop}} />
    */
   const ObjectExpressionsLiteralReplacement = (attribute) => {
     const results = attribute.find(j.Property, {
       kind: "init",
-      key: { name: old },
+      key: { name: prop },
       shorthand: false,
     });
 
     if (results.size()) {
-      if (replacement) {
-        results.get("key").replace(j.identifier(replacement));
-      } else {
-        results.remove();
-      }
-      return true;
+      return ObjectExpressionsLiteralReplacementFn(results, j);
     }
   };
 
   /*
-   * <Component {...{old}} />
+   * <Component {...{prop}} />
    */
   const ObjectExpressionsIdentifierReplacement = (argument) => {
     const results = argument.find(j.Property, {
       kind: "init",
-      key: { name: old },
+      key: { name: prop },
       shorthand: true,
     });
 
     if (results.size()) {
-      if (replacement) {
-        results.get("key").replace(j.identifier(replacement));
-        results.get().node.shorthand = false;
-      } else {
-        results.remove();
-      }
-      return true;
+      return ObjectExpressionsIdentifierReplacementFn(results, j);
     }
   };
 
   /*
   <Component {...{}} />
   */
-  const JSXSpreadAttributeObjectReplacement = (message) => {
+  const JSXSpreadAttributeObjectReplacement = (component) => {
     let didUpdate = false;
-    const objectExpressions = message.find(j.JSXSpreadAttribute, {
+    const objectExpressions = component.find(j.JSXSpreadAttribute, {
       argument: {
         type: "ObjectExpression",
       },
@@ -149,35 +112,30 @@ const renameAttribute = (path, old, replacement) => (
 
       const results = declaration.find(j.Property, {
         kind: "init",
-        key: { name: old },
+        key: { name: prop },
       });
 
       if (results.size()) {
-        if (replacement) {
-          results.get("key").replace(j.identifier(replacement));
-        } else {
-          results.remove();
-        }
-        didUpdate = true;
+        didUpdate = JSXSpreadAttributeIdentifierReplacementFn(results, j);
       }
     });
     return didUpdate;
   };
 
-  const messages = root.findJSXElementsByImport(path);
+  const components = root.findJSXElementsByImport(path);
 
-  if (messages.size() === 0) {
+  if (components.size() === 0) {
     // If the component is not imported, skip this file
     return;
   }
 
-  return messages.paths().reduce((didReplacement, path) => {
-    const message = j(path);
+  return components.paths().reduce((didReplacement, path) => {
+    const component = j(path);
     // Ensure that we run all possible combinations in case an attribute is defined more than once
     const result = [
-      JSXAttributeReplacement(message),
-      JSXSpreadAttributeIdentifierReplacement(message),
-      JSXSpreadAttributeObjectReplacement(message),
+      JSXAttributeReplacement(component),
+      JSXSpreadAttributeIdentifierReplacement(component),
+      JSXSpreadAttributeObjectReplacement(component),
     ].reduce((acc, cur) => {
       return acc || cur;
     }, false);
@@ -186,10 +144,4 @@ const renameAttribute = (path, old, replacement) => (
   }, false);
 };
 
-const removeAttribute = (path, attribute) => renameAttribute(path, attribute);
-
-module.exports = {
-  run,
-  renameAttribute,
-  removeAttribute,
-};
+export default finder;

--- a/transforms/builder/index.js
+++ b/transforms/builder/index.js
@@ -1,0 +1,11 @@
+import run from "./run";
+import renameAttribute from "./renameAttribute";
+import removeAttribute from "./removeAttribute";
+import replaceAttributeValue from "./replaceAttributeValue";
+
+module.exports = {
+  run,
+  renameAttribute,
+  removeAttribute,
+  replaceAttributeValue,
+};

--- a/transforms/builder/removeAttribute.js
+++ b/transforms/builder/removeAttribute.js
@@ -1,0 +1,26 @@
+import finder from "./finder";
+
+const removeAttribute = (path, attribute) =>
+  finder(path, attribute, {
+    JSXAttributeReplacement: (attributes) => {
+      attributes.remove();
+      return true;
+    },
+
+    ObjectExpressionsLiteralReplacement: (results, j) => {
+      results.remove();
+      return true;
+    },
+
+    ObjectExpressionsIdentifierReplacement: (results, j) => {
+      results.remove();
+      return true;
+    },
+
+    JSXSpreadAttributeIdentifierReplacement: (results, j) => {
+      results.remove();
+      return true;
+    },
+  });
+
+export default removeAttribute;

--- a/transforms/builder/renameAttribute.js
+++ b/transforms/builder/renameAttribute.js
@@ -1,0 +1,29 @@
+import finder from "./finder";
+
+const renameAttribute = (path, attribute, replacement) =>
+  finder(path, attribute, {
+    JSXAttributeReplacement: (attributes) => {
+      attributes.forEach((nodePath) => {
+        nodePath.node.name = replacement;
+      });
+      return true;
+    },
+
+    ObjectExpressionsLiteralReplacement: (results, j) => {
+      results.get("key").replace(j.identifier(replacement));
+      return true;
+    },
+
+    ObjectExpressionsIdentifierReplacement: (results, j) => {
+      results.get("key").replace(j.identifier(replacement));
+      results.get().node.shorthand = false;
+      return true;
+    },
+
+    JSXSpreadAttributeIdentifierReplacement: (results, j) => {
+      results.get("key").replace(j.identifier(replacement));
+      return true;
+    },
+  });
+
+export default renameAttribute;

--- a/transforms/builder/replaceAttributeValue.js
+++ b/transforms/builder/replaceAttributeValue.js
@@ -1,0 +1,145 @@
+import finder from "./finder";
+
+/*
+  <Component prop="value" />;
+ */
+const LiteralReplacement = (
+  j,
+  selectedAttribute,
+  attribute,
+  oldValue,
+  newValue
+) => {
+  if (selectedAttribute.find(j.Literal, { value: oldValue }).size()) {
+    let replacement = j.literal(newValue);
+    if (typeof newValue !== "string") {
+      replacement = j.jsxExpressionContainer(replacement);
+    }
+
+    selectedAttribute.replaceWith(
+      j.jsxAttribute(j.jsxIdentifier(attribute), replacement)
+    );
+    return true;
+  }
+};
+
+/*
+  const value = "something";
+  export default () => <Component prop={value} />;
+  */
+const JSXExpressionVariableReplacement = (
+  j,
+  IdentifierExpression,
+  oldValue,
+  newValue
+) => {
+  const result = IdentifierExpression.findVariableDeclaration(
+    IdentifierExpression.get("expression").value.name,
+    {
+      type: "Literal",
+      value: oldValue,
+    }
+  );
+  if (result.size()) {
+    result.get("init").replace(j.literal(newValue));
+    return true;
+  }
+};
+
+/*
+export const one = (value = "something") => {
+  return <Component prop={value} />;
+}
+*/
+const JSXExpressionAssignmentReplacement = (
+  j,
+  IdentifierExpression,
+  oldValue,
+  newValue
+) => {
+  const result = IdentifierExpression.findAssignmentPattern({
+    type: "Literal",
+    value: oldValue,
+  });
+  if (result.size()) {
+    result.get("right").replace(j.literal(newValue));
+    return true;
+  }
+};
+
+/*
+<Component prop={value}/>
+*/
+const JSXExpressionReplacement = (j, attribute, oldValue, newValue) => {
+  const IdentifierExpression = attribute.find(j.JSXExpressionContainer, {
+    expression: { type: "Identifier" },
+  });
+  if (IdentifierExpression.size() === 0) {
+    return false;
+  }
+
+  const didUpdate =
+    JSXExpressionVariableReplacement(
+      j,
+      IdentifierExpression,
+      oldValue,
+      newValue
+    ) ||
+    JSXExpressionAssignmentReplacement(
+      j,
+      IdentifierExpression,
+      oldValue,
+      newValue
+    );
+
+  return didUpdate;
+};
+
+const replaceAttributeValue = (path, attribute, oldValue, newValue) =>
+  finder(path, attribute, {
+    JSXAttributeReplacement: (attributes, j) => {
+      const selectedAttribute = attributes.last();
+
+      let didUpdate =
+        LiteralReplacement(
+          j,
+          selectedAttribute,
+          attribute,
+          oldValue,
+          newValue
+        ) || JSXExpressionReplacement(j, selectedAttribute, oldValue, newValue);
+      return didUpdate;
+    },
+
+    ObjectExpressionsLiteralReplacement: (results, j) => {
+      let didUpdate = false;
+      const value = results.get("value");
+      if (value.value.value === oldValue) {
+        value.replace(j.literal(newValue));
+        didUpdate = true;
+      }
+      return didUpdate;
+    },
+
+    ObjectExpressionsIdentifierReplacement: (results, j) => {
+      let didUpdate = false;
+      const value = results.get("value");
+      if (value.value.value === oldValue) {
+        value.replace(j.literal(newValue));
+        didUpdate = true;
+      }
+      return didUpdate;
+    },
+
+    JSXSpreadAttributeIdentifierReplacement: (results, j) => {
+      let didUpdate = false;
+      const value = results.get("value");
+      if (value.value.value === oldValue) {
+        value.replace(j.literal(newValue));
+        didUpdate = true;
+      }
+      return didUpdate;
+    },
+  });
+
+export default replaceAttributeValue;

--- a/transforms/builder/run.js
+++ b/transforms/builder/run.js
@@ -1,0 +1,21 @@
+import registerMethods from "./../registerMethods";
+
+const run = (...transformers) => {
+  return function rootTransformer(fileInfo, api, options) {
+    let didReplacement = false;
+    const j = api.jscodeshift;
+    registerMethods(j);
+    const root = j(fileInfo.source);
+
+    transformers.forEach((transformer) => {
+      const result = transformer(fileInfo, api, options, j, root);
+      didReplacement = didReplacement || result;
+    });
+
+    if (didReplacement) {
+      return root.toSource();
+    }
+  };
+};
+
+export default run;

--- a/transforms/replace-prop-value/README.md
+++ b/transforms/replace-prop-value/README.md
@@ -1,0 +1,64 @@
+# replace-prop-value
+
+This universal codemod provides possibility to replace any prop value in any component
+
+```js
+import Component from "carbon-react/lib/components/component";
+```
+```diff
+- <Component prop="something" />
++ <Component prop="something different" />
+```
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Component prop="something" />
+```
+
+```js
+<Component prop={"something"} />
+```
+
+```js
+const value = "something";
+
+<Component prop={value} />
+```
+
+```js
+const props = { prop: "something" };
+
+<Component {...props} />
+```
+
+```js
+<Component {...{ prop: "something" }} />
+```
+
+```js
+const prop = "something";
+
+<Component {...{ prop }} />
+```
+
+```js
+const value = "something";
+
+<Component {...{ prop: value }} />
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod replace-prop-value <target> <component-import-path> <prop> <old-value> <new-value>`
+
+Note: To use a numeric value as a string as `old-value` or `new-value`, format it as `\"string\"` on the command line, i.e.: 
+
+`npx carbon-codemod replace-prop-value src carbon-react/lib/components/tile padding \"2\" \"3\"`
+
+### Examples
+
+`npx carbon-codemod replace-prop-value src carbon-react/lib/components/tile padding 2 4`
+`npx carbon-codemod replace-prop-value src carbon-react/lib/components/tile padding XL 10px`

--- a/transforms/replace-prop-value/__testfixtures__/NoImport.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Wrong Import
+import Component from "carbon-react/lib/components/NotComponent";
+export default () => <Component />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberStringNewValue.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberStringNewValue.input.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="oldValue" />;
+export const withProps = () => <Component otherProp="Example" prop="oldValue" />
+
+const prop = "oldValue";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "oldValue", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "oldValue", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberStringNewValue.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberStringNewValue.output.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="2" />;
+export const withProps = () => <Component otherProp="Example" prop="2" />
+
+const prop = "2";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "2", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "2", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberStringOldValue.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberStringOldValue.input.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="3" />;
+export const withProps = () => <Component otherProp="Example" prop="3" />
+
+const prop = "3";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "3", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "3", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberStringOldValue.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberStringOldValue.output.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="newValue" />;
+export const withProps = () => <Component otherProp="Example" prop="newValue" />
+
+const prop = "newValue";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "newValue", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "newValue", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberToNumber.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberToNumber.input.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop={3} />;
+export const withProps = () => <Component otherProp="Example" prop={3} />
+
+const prop = 3;
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: 3, otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: 3, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberToNumber.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberToNumber.output.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop={2} />;
+export const withProps = () => <Component otherProp="Example" prop={2} />
+
+const prop = 2;
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: 2, otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: 2, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberToString.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberToString.input.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop={3} />;
+export const withProps = () => <Component otherProp="Example" prop={3} />
+
+const prop = 3;
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: 3, otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: 3, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NumberToString.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/NumberToString.output.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="newString" />;
+export const withProps = () => <Component otherProp="Example" prop="newString" />
+
+const prop = "newString";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "newString", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "newString", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/StringToNumber.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/StringToNumber.input.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="oldString" />;
+export const withProps = () => <Component otherProp="Example" prop="oldString" />
+
+const prop = "oldString";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "oldString", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "oldString", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/StringToNumber.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/StringToNumber.output.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop={2} />;
+export const withProps = () => <Component otherProp="Example" prop={2} />
+
+const prop = 2;
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: 2, otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: 2, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/StringToString.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/StringToString.input.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="oldString" />;
+export const withProps = () => <Component otherProp="Example" prop="oldString" />
+
+const prop = "oldString";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "oldString", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "oldString", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/StringToString.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/StringToString.output.js
@@ -1,0 +1,13 @@
+import Component from "carbon-react/lib/components/component";
+
+export default () => <Component prop="newString" />;
+export const withProps = () => <Component otherProp="Example" prop="newString" />
+
+const prop = "newString";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "newString", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "newString", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__tests__/replace-prop-value.js
+++ b/transforms/replace-prop-value/__tests__/replace-prop-value.js
@@ -1,0 +1,85 @@
+import defineTest from "../../../defineTest";
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: "test",
+    newValue: 3,
+  },
+  "NoImport"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: "oldString",
+    newValue: "newString",
+  },
+  "StringToString"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: "oldString",
+    newValue: 2,
+  },
+  "StringToNumber"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: 3,
+    newValue: "newString",
+  },
+  "NumberToString"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: 3,
+    newValue: 2,
+  },
+  "NumberToNumber"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: "3",
+    newValue: "newValue",
+  },
+  "NumberStringOldValue"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    component: "carbon-react/lib/components/component",
+    attribute: "prop",
+    oldValue: "oldValue",
+    newValue: "2",
+  },
+  "NumberStringNewValue"
+);

--- a/transforms/replace-prop-value/replace-prop-value.js
+++ b/transforms/replace-prop-value/replace-prop-value.js
@@ -1,0 +1,26 @@
+/*
+ * Convert all <Component prop="something" /> to <Component prop="somethingelse" />
+ */
+import { replaceAttributeValue } from "../builder";
+import registerMethods from "../registerMethods";
+
+const transformer = (fileInfo, api, options) => {
+  const j = api.jscodeshift;
+  registerMethods(j);
+  const root = j(fileInfo.source);
+
+  const { component, attribute, oldValue, newValue } = options;
+
+  const result = replaceAttributeValue(
+    component,
+    attribute,
+    oldValue,
+    newValue
+  )(fileInfo, api, options, j, root);
+
+  if (result) {
+    return root.toSource();
+  }
+};
+
+module.exports = transformer;

--- a/transforms/tile-update-padding-prop/README.md
+++ b/transforms/tile-update-padding-prop/README.md
@@ -1,0 +1,16 @@
+# tile-update-padding-prop
+
+In order to accomodate the `styled-system` spacing api being added to Carbon components, the `padding` prop on `Tile` has been replaced with `p`. 
+
+Currently `padding` accepts the values `XS`, `S`, `M`, `L` and `XL` which map to paddings of `8px` up to `40px`. This codemod will replace these with the `styled-system` equivalent. I.e. for `padding="XS"` this will be `p={1}`, both of which map to `8px`.
+
+```diff
+- <Tile padding="XS">Content</Tile>
++ <Tile p={1}>Content</Tile>
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage 
+
+`npx carbon-codemod tile-update-padding-prop <target>`

--- a/transforms/tile-update-padding-prop/__testfixtures__/Basic.input.js
+++ b/transforms/tile-update-padding-prop/__testfixtures__/Basic.input.js
@@ -1,0 +1,18 @@
+import Tile from "carbon-react/lib/components/tile";
+export const xs = () => <Tile padding="XS" />;
+export const s = () => <Tile padding="S" />;
+export const m = () => <Tile padding="M" />;
+export const l = () => <Tile padding="L" />;
+export const xl = () => <Tile padding="XL" />;
+
+export default () => <Tile padding="S" />;
+export const withProps = () => <Tile otherProp="Example" padding="L" />
+
+const padding = "XS";
+export const asVariable = () => <Tile padding={padding} />;
+
+const props = { padding: "S", otherProp: "Example" }
+export const spread = () => <Tile {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Tile {...{ padding: "S", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Tile {...{ padding, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Tile {...{ padding: padding, otherProp: "Example" }} />;

--- a/transforms/tile-update-padding-prop/__testfixtures__/Basic.output.js
+++ b/transforms/tile-update-padding-prop/__testfixtures__/Basic.output.js
@@ -1,0 +1,18 @@
+import Tile from "carbon-react/lib/components/tile";
+export const xs = () => <Tile p={1} />;
+export const s = () => <Tile p={2} />;
+export const m = () => <Tile p={3} />;
+export const l = () => <Tile p={4} />;
+export const xl = () => <Tile p={5} />;
+
+export default () => <Tile p={2} />;
+export const withProps = () => <Tile otherProp="Example" p={4} />
+
+const padding = 1;
+export const asVariable = () => <Tile p={padding} />;
+
+const props = { p: 2, otherProp: "Example" }
+export const spread = () => <Tile {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Tile {...{ p: 2, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Tile {...{ p: padding, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Tile {...{ p: padding, otherProp: "Example" }} />;

--- a/transforms/tile-update-padding-prop/__testfixtures__/Bug.input.js
+++ b/transforms/tile-update-padding-prop/__testfixtures__/Bug.input.js
@@ -1,0 +1,2 @@
+import Tile from "carbon-react/lib/components/tile";
+export default ({ padding, ...props }) => <Tile padding={padding} {...props}>Example</Tile>;

--- a/transforms/tile-update-padding-prop/__testfixtures__/Bug.output.js
+++ b/transforms/tile-update-padding-prop/__testfixtures__/Bug.output.js
@@ -1,0 +1,2 @@
+import Tile from "carbon-react/lib/components/tile";
+export default ({ padding, ...props }) => <Tile p={padding} {...props}>Example</Tile>;

--- a/transforms/tile-update-padding-prop/__testfixtures__/NoImport.input.js
+++ b/transforms/tile-update-padding-prop/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Wrong Import
+import Tile from "carbon-react/lib/components/NotTile";
+export default () => <Tile />;

--- a/transforms/tile-update-padding-prop/__tests__/tile-update-padding-prop.js
+++ b/transforms/tile-update-padding-prop/__tests__/tile-update-padding-prop.js
@@ -1,0 +1,5 @@
+import defineTest from "../../../defineTest";
+
+defineTest(__dirname, "tile-update-padding-prop", null, "Basic");
+defineTest(__dirname, "tile-update-padding-prop", null, "Bug");
+defineTest(__dirname, "tile-update-padding-prop", null, "NoImport");

--- a/transforms/tile-update-padding-prop/tile-update-padding-prop.js
+++ b/transforms/tile-update-padding-prop/tile-update-padding-prop.js
@@ -1,0 +1,13 @@
+/*
+ * Convert all <Tile padding="" /> to <Tile p="" />
+ */
+import { run, renameAttribute, replaceAttributeValue } from "../builder";
+
+module.exports = run(
+  replaceAttributeValue("carbon-react/lib/components/tile", "padding", "XS", 1),
+  replaceAttributeValue("carbon-react/lib/components/tile", "padding", "S", 2),
+  replaceAttributeValue("carbon-react/lib/components/tile", "padding", "M", 3),
+  replaceAttributeValue("carbon-react/lib/components/tile", "padding", "L", 4),
+  replaceAttributeValue("carbon-react/lib/components/tile", "padding", "XL", 5),
+  renameAttribute("carbon-react/lib/components/tile", "padding", "p")
+);


### PR DESCRIPTION
### Proposed behaviour

Add `replace-prop-value` codemod which can replace the value for a prop for any component.

Add `tile-update-padding-prop` codemod which replaces the `padding` prop on `Tile` to be `p` and updates the values as below: 

"XS" -> 1 
"S" -> 2
"M" -> 3
"L" -> 4
"XL" -> 5

### Current behaviour

These codemods do not currently exist.

### Checklist

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [ ] Readme updated

### Additional context

### Testing instructions
