### PR TITLE
feat: add codemod to replace flash with toast - FE-3254

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -112,6 +112,11 @@ function Cli() {
     .action((target, command) => runTransform(target, command, program));
 
   program
+    .command("replace-flash-with-toast <target>")
+    .description("Replaces deprecated Flash component with Toast component")
+    .action((target, command) => runTransform(target, command, program));
+
+  program
     .command("tile-update-padding-prop <target>")
     .description(
       "Replace padding prop with p prop and change values on tile component"

--- a/transforms/builder/finder.js
+++ b/transforms/builder/finder.js
@@ -4,6 +4,49 @@
  * @param {string} prop prop name to operate on
  * @param {string} replacement new prop name
  */
+
+/*
+ * <Component prop="" />
+ */
+export const findJSXAttribute = (j, component, prop) =>
+  component.find(j.JSXAttribute, {
+    name: {
+      type: "JSXIdentifier",
+      name: prop,
+    },
+  });
+
+/*
+ * <Component {...{prop: 'info'}} />
+ * <Component {...{prop: prop}} />
+ */
+export const findObjectExpressionsLiteral = (j, attribute, prop) =>
+  attribute.find(j.Property, {
+    kind: "init",
+    key: { name: prop },
+    shorthand: false,
+  });
+
+/*
+ * <Component {...{prop}} />
+ */
+export const findObjectExpressionsIdentifier = (j, argument, prop) =>
+  argument.find(j.Property, {
+    kind: "init",
+    key: { name: prop },
+    shorthand: true,
+  });
+
+/*
+ *   <Component {...{}} />
+ */
+export const findJSXSpreadAttributeObject = (j, component) =>
+  component.find(j.JSXSpreadAttribute, {
+    argument: {
+      type: "ObjectExpression",
+    },
+  });
+
 const finder = (
   path,
   prop,
@@ -18,12 +61,7 @@ const finder = (
    * <Component prop="" />
    */
   const JSXAttributeReplacement = (component) => {
-    const attributes = component.find(j.JSXAttribute, {
-      name: {
-        type: "JSXIdentifier",
-        name: prop,
-      },
-    });
+    const attributes = findJSXAttribute(j, component, prop);
 
     if (attributes.size()) {
       return JSXAttributeReplacementFn(attributes, j);
@@ -35,11 +73,7 @@ const finder = (
    * <Component {...{prop: prop}} />
    */
   const ObjectExpressionsLiteralReplacement = (attribute) => {
-    const results = attribute.find(j.Property, {
-      kind: "init",
-      key: { name: prop },
-      shorthand: false,
-    });
+    const results = findObjectExpressionsLiteral(j, attribute, prop);
 
     if (results.size()) {
       return ObjectExpressionsLiteralReplacementFn(results, j);
@@ -50,11 +84,7 @@ const finder = (
    * <Component {...{prop}} />
    */
   const ObjectExpressionsIdentifierReplacement = (argument) => {
-    const results = argument.find(j.Property, {
-      kind: "init",
-      key: { name: prop },
-      shorthand: true,
-    });
+    const results = findObjectExpressionsIdentifier(j, argument, prop);
 
     if (results.size()) {
       return ObjectExpressionsIdentifierReplacementFn(results, j);
@@ -66,11 +96,9 @@ const finder = (
   */
   const JSXSpreadAttributeObjectReplacement = (component) => {
     let didUpdate = false;
-    const objectExpressions = component.find(j.JSXSpreadAttribute, {
-      argument: {
-        type: "ObjectExpression",
-      },
-    });
+
+    const objectExpressions = findJSXSpreadAttributeObject(j, component);
+
     objectExpressions.forEach((path) => {
       const attribute = j(path);
       const result =

--- a/transforms/builder/renameAttribute.js
+++ b/transforms/builder/renameAttribute.js
@@ -2,9 +2,11 @@ import finder from "./finder";
 
 const renameAttribute = (path, attribute, replacement) =>
   finder(path, attribute, {
-    JSXAttributeReplacement: (attributes) => {
+    JSXAttributeReplacement: (attributes, j) => {
       attributes.forEach((nodePath) => {
-        nodePath.node.name = replacement;
+        j(nodePath)
+          .find(j.JSXIdentifier)
+          .replaceWith(j.jsxIdentifier(replacement));
       });
       return true;
     },

--- a/transforms/replace-flash-with-toast/README.md
+++ b/transforms/replace-flash-with-toast/README.md
@@ -1,0 +1,59 @@
+# replace-flash-with-toast
+
+The `Flash` component has been deprecated in favour of `Toast` component. This codemod converts all `Flash` instances to `Toast`
+
+```diff
+- import Flash from "carbon-react/lib/components/flash";
++ import Toast from "carbon-react/lib/components/toast";
+
+- <Flash message="hello" />
++ <Toast variant="success" isCenter>hello</Toast>
+```
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Flash prop="something" />
+```
+
+```js
+<Flash prop={"something"} />
+```
+
+```js
+const value = "something";
+
+<Flash prop={value} />;
+```
+
+```js
+const props = { prop: "something" };
+
+<Flash {...props} />;
+```
+
+```js
+<Flash {...{ prop: "something" }} />
+```
+
+```js
+const prop = "something";
+
+<Flash {...{ prop }} />;
+```
+
+```js
+const value = "something";
+
+<Flash {...{ prop: value }} />;
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod replace-flash-with-toast <target>`
+
+### Example
+
+`npx carbon-codemod replace-prop-value src`

--- a/transforms/replace-flash-with-toast/__testfixtures__/Basic.input.js
+++ b/transforms/replace-flash-with-toast/__testfixtures__/Basic.input.js
@@ -1,0 +1,10 @@
+import Flash from "carbon-react/lib/components/flash";
+export default () => <Flash message="info" />;
+export const withProps = () => <Flash message="info" random="Example" isCenter/>;
+const message = "info";
+export const asVariable = () => <Flash message={message} />;
+const props = { message: "info", variant: 'info', random: "Example" }
+export const spread = () => <Flash {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Flash {...{ message: "info", random: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Flash {...{ message, random: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Flash {...{ message: message, random: "Example" }} />;

--- a/transforms/replace-flash-with-toast/__testfixtures__/Basic.output.js
+++ b/transforms/replace-flash-with-toast/__testfixtures__/Basic.output.js
@@ -1,0 +1,10 @@
+import Toast from "carbon-react/lib/components/toast";
+export default () => <Toast variant="success" isCenter>info</Toast>;
+export const withProps = () => <Toast random="Example" isCenter variant="success">info</Toast>;
+const message = "info";
+export const asVariable = () => <Toast variant="success" isCenter>{message}</Toast>;
+const props = { message: "info", variant: 'info', random: "Example" }
+export const spread = () => <Toast isCenter {...props}>{props.message}</Toast>;
+export const ObjectExpressionsLiteralReplacement = () => <Toast variant="success" isCenter {...{ message: "info", random: "Example" }}>info</Toast>;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Toast variant="success" isCenter {...{ message, random: "Example" }}>{message}</Toast>;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Toast variant="success" isCenter {...{ message: message, random: "Example" }}>{message}</Toast>;

--- a/transforms/replace-flash-with-toast/__testfixtures__/NoImport.input.js
+++ b/transforms/replace-flash-with-toast/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Wrong Import
+import Flash from "carbon-react/lib/components/StrangeFlash";
+export default () => <Flash message="flash" />;

--- a/transforms/replace-flash-with-toast/__testfixtures__/ToastAndFlashImports.input.js
+++ b/transforms/replace-flash-with-toast/__testfixtures__/ToastAndFlashImports.input.js
@@ -1,0 +1,9 @@
+import Flash from "carbon-react/lib/components/flash";
+import Toast from "carbon-react/lib/components/toast";
+export default () => 
+(
+  <>
+    <Flash message="test-message" />
+    <Toast>hello</Toast>
+  </>
+);

--- a/transforms/replace-flash-with-toast/__testfixtures__/ToastAndFlashImports.output.js
+++ b/transforms/replace-flash-with-toast/__testfixtures__/ToastAndFlashImports.output.js
@@ -1,0 +1,8 @@
+import Toast from "carbon-react/lib/components/toast";
+export default () => 
+(
+  <>
+    <Toast variant="success" isCenter>test-message</Toast>
+    <Toast>hello</Toast>
+  </>
+);

--- a/transforms/replace-flash-with-toast/__tests__/replace-flash-with-toast-test.js
+++ b/transforms/replace-flash-with-toast/__tests__/replace-flash-with-toast-test.js
@@ -1,0 +1,5 @@
+import defineTest from "../../../defineTest";
+
+defineTest(__dirname, "replace-flash-with-toast", null, "Basic");
+defineTest(__dirname, "replace-flash-with-toast", null, "NoImport");
+defineTest(__dirname, "replace-flash-with-toast", null, "ToastAndFlashImports");

--- a/transforms/replace-flash-with-toast/replace-flash-with-toast.js
+++ b/transforms/replace-flash-with-toast/replace-flash-with-toast.js
@@ -1,0 +1,252 @@
+import {
+  findJSXAttribute,
+  findObjectExpressionsLiteral,
+  findObjectExpressionsIdentifier,
+  findJSXSpreadAttributeObject,
+} from "../builder/finder";
+
+import renameAttribute from "../builder/renameAttribute";
+
+import registerMethods from "../registerMethods";
+
+const flashImportString = "carbon-react/lib/components/flash";
+const toastImportString = "carbon-react/lib/components/toast";
+
+function transformer(fileInfo, api, options) {
+  const j = api.jscodeshift;
+  registerMethods(j);
+
+  const root = j(fileInfo.source);
+
+  /*
+    Change import from 'import Flash from "carbon-react/lib/components/flash";'
+    to 'import Toast from "carbon-react/lib/components/toast";'
+  */
+
+  const replaceImport = () => {
+    // Flash import
+    const flashImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: flashImportString,
+      },
+    });
+
+    // Toast import
+    let toastImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: toastImportString,
+      },
+    });
+
+    // If there's already a Toast import, just remove the Flash one
+    if (toastImport.size()) {
+      flashImport.remove();
+      return true;
+    }
+
+    // if no Toast import exists already add one
+    toastImport = j.importDeclaration(
+      [j.importDefaultSpecifier(j.identifier("Toast"))],
+      j.stringLiteral(toastImportString)
+    );
+
+    // replace Flash import with Toast import
+    flashImport.replaceWith(toastImport);
+
+    return true;
+  };
+
+  const getProp = (flash, propName) => {
+    // <Flash propName="message" />
+    // <Flash propName={message} />
+    let propLiteral = findJSXAttribute(j, flash, propName);
+
+    if (propLiteral.size()) {
+      return propLiteral.get("value").value || true;
+    }
+
+    // <Flash {...{}} />
+    const jsxSpreadAttribute = findJSXSpreadAttributeObject(j, flash);
+
+    //  <Flash {...{propName: 'info'}} />
+    //  <Flash {...{propName: prop}} />
+    propLiteral = findObjectExpressionsLiteral(j, jsxSpreadAttribute, propName);
+
+    if (propLiteral.size()) {
+      const literalMessageValue = propLiteral.get("value").value;
+      if (literalMessageValue.type === "Literal") {
+        return literalMessageValue;
+      }
+      return j.jsxExpressionContainer(
+        j.jsxIdentifier(literalMessageValue.name)
+      );
+    }
+
+    //  <Flash {...{propName}} />
+    propLiteral = findObjectExpressionsIdentifier(
+      j,
+      jsxSpreadAttribute,
+      propName
+    );
+
+    if (propLiteral.size()) {
+      const name = propLiteral.get("value").value.name;
+      return j.jsxExpressionContainer(j.jsxIdentifier(name));
+    }
+
+    //  <Flash {...props} />
+    const jsxSpreadIdentifier = flash.find(j.JSXSpreadAttribute, {
+      argument: {
+        type: "Identifier",
+      },
+    });
+
+    if (jsxSpreadIdentifier.size()) {
+      let memberExpression;
+      jsxSpreadIdentifier.forEach((path) => {
+        const attribute = j(path);
+        const expressionName = attribute.get("argument", "name").value;
+        const declarationScope = attribute.findDeclarationScope(expressionName);
+        if (!declarationScope) {
+          return;
+        }
+
+        const declaration = j(declarationScope.path)
+          .find(j.VariableDeclarator, {
+            id: {
+              type: "Identifier",
+              name: expressionName,
+            },
+            init: {
+              type: "ObjectExpression",
+            },
+          })
+          .filter((path) => path.scope === declarationScope);
+
+        const results = declaration.find(j.Property, {
+          kind: "init",
+          key: { name: propName },
+        });
+
+        if (results.size()) {
+          memberExpression = j.jsxExpressionContainer(
+            j.memberExpression(
+              j.identifier(expressionName),
+              j.identifier(propName)
+            )
+          );
+        }
+      });
+      return memberExpression;
+    }
+  };
+
+  const replaceOpeningTag = (tag) => {
+    const filteredAttributes = tag
+      .find(j.JSXAttribute)
+      .filter((path) => j(path).get("name").value.name !== "message");
+    const props = [...filteredAttributes.nodes()];
+
+    if (!getProp(tag, "variant")) {
+      props.push(
+        j.jsxAttribute(j.jsxIdentifier("variant"), j.literal("success"))
+      );
+    }
+
+    if (!getProp(tag, "isCenter")) {
+      props.push(j.jsxAttribute(j.jsxIdentifier("isCenter")));
+    }
+
+    const currentSpreadAttributes = tag.find(j.JSXSpreadAttribute);
+    props.push(...currentSpreadAttributes.nodes());
+
+    tag.replaceWith(
+      j.jsxOpeningElement(j.jsxIdentifier("Toast"), props, false)
+    );
+  };
+
+  const replaceChildren = (flash) => {
+    const message = getProp(flash, "message");
+    if (message) {
+      flash.get("children").replace([message]);
+    }
+  };
+
+  const replaceClosingTag = (tag) => {
+    // Change the tag from Flash to Toast
+    const name = tag.find(j.JSXIdentifier, { name: "Flash" });
+    name.replaceWith(j.jsxIdentifier("Toast"));
+  };
+
+  const addClosingTag = (flash) => {
+    // Add closing Flash tag
+    flash
+      .get("closingElement")
+      .replace(j.jsxClosingElement(j.jsxIdentifier("Toast")));
+  };
+
+  const replaceJSXElement = (flash) => {
+    // Opening tag
+    const flashOpeningTags = flash.find(j.JSXOpeningElement, {
+      name: {
+        type: "JSXIdentifier",
+        name: "Flash",
+      },
+    });
+
+    // Closing tag. If it doesn't exist, the opening tag is self closing
+    const flashClosingTags = flash.find(j.JSXClosingElement, {
+      name: {
+        type: "JSXIdentifier",
+        name: "Flash",
+      },
+    });
+
+    replaceChildren(flash);
+
+    replaceOpeningTag(flashOpeningTags.last());
+
+    if (flashClosingTags.size()) {
+      const closingTag = flashClosingTags.last();
+      replaceClosingTag(closingTag);
+    } else {
+      addClosingTag(flash);
+    }
+  };
+
+  const flashComponents = root.findJSXElementsByImport(flashImportString);
+
+  // if the component is not imported, skip this file
+  if (flashComponents.size() === 0) {
+    return;
+  }
+
+  // Change 'as' prop name to 'variant' in all Flash components
+  renameAttribute(flashImportString, "as", "variant")(
+    fileInfo,
+    api,
+    options,
+    j,
+    root
+  );
+
+  let didReplaceImport = false;
+
+  flashComponents.forEach((path) => {
+    // if import was not already replaced
+    if (!didReplaceImport) {
+      didReplaceImport = replaceImport();
+    }
+    const flash = j(path);
+    replaceJSXElement(flash);
+  });
+
+  // transform if update occurred
+  if (didReplaceImport) {
+    return root.toSource();
+  }
+}
+
+module.exports = transformer;


### PR DESCRIPTION
This PR adds a codemod that transforms all uses of deprecated `Flash` component to `Toast` component.

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

