### PR TITLE
fix(message): remove border prop

### DIFF
--- a/transforms/message-remove-classic-theme/README.md
+++ b/transforms/message-remove-classic-theme/README.md
@@ -5,7 +5,7 @@ In order to simplify the `Message` api in carbon-react
 * the `roundedCorners` prop has been removed
 
 ```diff
-- <Message as="info" roundedCorners>My Message</Message>
+- <Message as="info" roundedCorners border={false}>My Message</Message>
 + <Message variant="info">My Message</Message>
 ```
 

--- a/transforms/message-remove-classic-theme/__testfixtures__/Basic.input.js
+++ b/transforms/message-remove-classic-theme/__testfixtures__/Basic.input.js
@@ -3,9 +3,9 @@ export default () => <Message as="info" roundedCorners />;
 export const withProps = () => <Message as="info" title="Example" roundedCorners={true} />;
 const as = "info";
 const roundedCorners = true;
-export const asVariable = () => <Message as={as} roundedCorners={roundedCorners} />;
-const props = { as: "info", title: "Example", roundedCorners: true }
-export const spread = () => <Message {...props} roundedCorners />;
-export const ObjectExpressionsLiteralReplacement = () => <Message {...{ as: "info", title: "Example", roundedCorners: true }} />;
-export const ObjectExpressionsIdentifierReplacement1 = () => <Message {...{ as, title: "Example", roundedCorners }} />;
-export const ObjectExpressionsIdentifierReplacement2 = () => <Message {...{ as: as, title: "Example", roundedCorners: roundedCorners }} />;
+export const asVariable = () => <Message as={as} roundedCorners={roundedCorners} border={false}/>;
+const props = { as: "info", title: "Example", roundedCorners: true, border: false }
+export const spread = () => <Message {...props} roundedCorners border={false}/>;
+export const ObjectExpressionsLiteralReplacement = () => <Message {...{ as: "info", title: "Example", roundedCorners: true, border: false }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Message {...{ as, title: "Example", roundedCorners, border: false }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Message {...{ as: as, title: "Example", roundedCorners: roundedCorners, border: false }} />;

--- a/transforms/message-remove-classic-theme/message-remove-classic-theme.js
+++ b/transforms/message-remove-classic-theme/message-remove-classic-theme.js
@@ -1,8 +1,9 @@
 /*
- * Convert all <Message as="" roundedCorners /> to <Message variant="" />
+ * Convert all <Message as="" roundedCorners border={false} /> to <Message variant="" />
  */
 import { run, renameAttribute, removeAttribute } from "../builder";
 module.exports = run(
   renameAttribute("carbon-react/lib/components/message", "as", "variant"),
-  removeAttribute("carbon-react/lib/components/message", "roundedCorners")
+  removeAttribute("carbon-react/lib/components/message", "roundedCorners"),
+  removeAttribute("carbon-react/lib/components/message", "border")
 );


### PR DESCRIPTION
### Proposed behaviour

Remove the `border` prop from the `Message` component.

### Current behaviour

Codemod exists but does not remove this redundant prop.

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

### Additional context

Required for the removal of classic theme from `Message`

### Testing instructions

Ensure unit tests are passing
