### PR TITLE
feat: add named import support to universal codemods

### DIFF
--- a/bin/__tests__/carbon-codemod.js
+++ b/bin/__tests__/carbon-codemod.js
@@ -246,7 +246,7 @@ describe("run", () => {
         "--transform",
         path.join(Cli.__transformsDir, "rename-prop", "rename-prop.js"),
         path.join(process.cwd(), "src"),
-        "--component=carbon-react/lib/components/button",
+        "--importPath=carbon-react/lib/components/button",
         "--old=buttonType",
         "--replacement=variant",
       ];
@@ -272,7 +272,7 @@ describe("run", () => {
         "--transform",
         path.join(Cli.__transformsDir, "remove-prop", "remove-prop.js"),
         path.join(process.cwd(), "src"),
-        "--component=carbon-react/lib/components/button",
+        "--importPath=carbon-react/lib/components/button",
         "--prop=buttonType",
       ];
       expect(console.log).toBeCalledWith(`jscodeshift ${args.join(" ")}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -124,81 +124,132 @@ function Cli() {
     .action((target, command) => runTransform(target, command, program));
 
   program
-    .command("add-prop <target> <component> <prop> <value>")
+    .command("add-prop <target> <import-path> <prop> <value>")
+    .option("-i, --import-name <import-name>", "component named import name")
     .description("adds a new prop and value to the specified component")
-    .action((target, component, prop, value, command) =>
-      runTransform(target, command, program, { component, prop, value })
-    );
+    .description(
+      `
+Codemod used for adding a new prop
+Usage
+  npx carbon-codemod add-prop <target> <import-path> <prop> <value>
+
+  target       Files or directory to transform
+  import-path  Import path of component
+  prop         Prop name
+  value        Prop value
+
+Options
+  --import-name:  Component named import name
+
+Example
+  default import:  npx carbon-codemod add-prop src carbon-react/lib/component propName propValue
+  named import:    npx carbon-codemod add-prop src carbon-react/lib/component propName propValue -i Component
+    `
+    )
+    .action((target, importPath, prop, value, command) => {
+      const { importName } = command;
+      runTransform(target, command, program, {
+        importPath,
+        prop,
+        value,
+        importName,
+      });
+    });
 
   program
-    .command("rename-prop <target> <component> <old> <replacement>")
+    .command("rename-prop <target> <import-path> <old> <replacement>")
+    .option("-i, --import-name <import-name>", "component named import name")
     .description(
       `
 Codemod used for prop renaming
 Usage
-  npx carbon-codemod rename-prop <target> <component> <old> <replacement>
+  npx carbon-codemod rename-prop <target> <import-path> <old> <replacement>
 
   target       Files or directory to transform
-  component    Import path of component which prop should be renamed
+  import-path  Import path of component which prop should be renamed
   old          Old prop name
   replacement  New prop name
 
+Options
+  --import-name:  Component named import name
+
 Example
-  npx carbon-codemod rename-prop src carbon-react/lib/components/component oldProp newProp
+  default import:  npx carbon-codemod rename-prop src carbon-react/lib/component oldProp newProp
+  named import:    npx carbon-codemod rename-prop src carbon-react/lib/component oldProp newProp -i Component
     `
     )
-    .action((target, component, old, replacement, command) =>
-      runTransform(target, command, program, { component, old, replacement })
-    );
+    .action((target, importPath, old, replacement, command) => {
+      const { importName } = command;
+      runTransform(target, command, program, {
+        importPath,
+        old,
+        replacement,
+        importName,
+      });
+    });
 
   program
-    .command("remove-prop <target> <component> <prop>")
+    .command("remove-prop <target> <import-path> <prop>")
+    .option("-i, --import-name <import-name>", "component named import name")
     .description(
       `
 Codemod used for prop removal
 Usage
-  npx carbon-codemod remove-prop <target> <component> <prop>
+  npx carbon-codemod remove-prop <target> <import-path> <prop>
 
   target       Files or directory to transform
-  component    Import path of component which prop should be removed
+  import-path  Import path of component which prop should be removed
   prop         Prop to be removed
 
+Options
+  --import-name:  Component named import name
+
 Example
-  npx carbon-codemod remove-prop src carbon-react/lib/components/component prop
+  default import:  npx carbon-codemod remove-prop src carbon-react/lib/component prop
+  named import:    npx carbon-codemod remove-prop src carbon-react/lib/component prop -i Component
     `
     )
-    .action((target, component, prop, command) =>
-      runTransform(target, command, program, { component, prop })
-    );
+    .action((target, importPath, prop, command) => {
+      const { importName } = command;
+      runTransform(target, command, program, { importPath, prop, importName });
+    });
 
   program
     .command(
-      "replace-prop-value <target> <component> <prop> <oldValue> <newValue>"
+      "replace-prop-value <target> <import-path> <prop> <oldValue> <newValue>"
     )
+    .option("-i, --import-name <import-name>", "component named import name")
     .description(
       `
 Codemod used for prop value changing
 Usage
-  npx carbon-codemod replace-prop-value <target> <component> <prop> <oldValue> <newValue>
+  npx carbon-codemod replace-prop-value <target> <import-path> <prop> <oldValue> <newValue>
 
   target       Files or directory to transform
-  component    Import path of component which prop should be renamed
+  import-path  Import path of component which prop should be renamed
   prop         Prop name
   oldValue     Prop value to change
   newValue     Value to change prop to
 
+Options
+  --import-name:  Component named import name
+
 Example
-  npx carbon-codemod replace-prop-value src carbon-react/lib/components/component prop oldValue newValue
+  default import:  npx carbon-codemod replace-prop-value src carbon-react/lib/component prop oldValue newValue
+  named import:    npx carbon-codemod replace-prop-value src carbon-react/lib/component prop oldValue newValue -i Component
     `
     )
-    .action((target, component, attribute, oldValue, newValue, command) =>
+    .action((target, importPath, attribute, oldValue, newValue, command) => {
+      const { importName } = command;
+
       runTransform(target, command, program, {
-        component,
+        importPath,
         attribute,
         oldValue,
         newValue,
-      })
-    );
+        importName,
+      });
+    });
 
   program.on("command:*", function () {
     console.error(

--- a/transforms/add-prop/README.md
+++ b/transforms/add-prop/README.md
@@ -7,13 +7,25 @@ This universal codemod provides possibility to add any prop to any component.
 + <Component newProp="info" />
 
 ```
+
 ## Usage
+
+### Components imported as a default import:
 
 `npx carbon-codemod add-prop <target> <component-import-path> <prop> <value>`
 
-### Examples
+`npx carbon-codemod add-prop src carbon-react/lib/components/button newProp "info"`
+
+### Components imported as a named import:
+
+`npx carbon-codemod add-prop <target> <component-import-path> <prop> <value> -i <component-import-name>`
+
+`npx carbon-codemod add-prop src carbon-react/lib/components/accordion newProp "info" -i Accordion`
+
+## Examples
 
 ### String
+
 `npx carbon-codemod add-prop src carbon-react/lib/components/button ml "16px"`
 
 ```diff
@@ -22,6 +34,7 @@ This universal codemod provides possibility to add any prop to any component.
 ```
 
 ### Number
+
 `npx carbon-codemod add-prop src carbon-react/lib/components/button ml 2`
 
 ```diff
@@ -30,6 +43,7 @@ This universal codemod provides possibility to add any prop to any component.
 ```
 
 ### Boolean - True
+
 `npx carbon-codemod add-prop src carbon-react/lib/components/button hasBorder true`
 
 ```diff
@@ -38,6 +52,7 @@ This universal codemod provides possibility to add any prop to any component.
 ```
 
 ### Boolean - False
+
 `npx carbon-codemod add-prop src carbon-react/lib/components/button hasBorder false`
 
 ```diff

--- a/transforms/add-prop/__testfixtures__/NamedImport.input.js
+++ b/transforms/add-prop/__testfixtures__/NamedImport.input.js
@@ -1,0 +1,3 @@
+import { Button } from "carbon-react/lib/components/button";
+
+export const asString = () => <Button />

--- a/transforms/add-prop/__testfixtures__/NamedImport.output.js
+++ b/transforms/add-prop/__testfixtures__/NamedImport.output.js
@@ -1,0 +1,3 @@
+import { Button } from "carbon-react/lib/components/button";
+
+export const asString = () => <Button import="named" />

--- a/transforms/add-prop/__tests__/add-prop.js
+++ b/transforms/add-prop/__tests__/add-prop.js
@@ -4,7 +4,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "ml",
     value: 2,
   },
@@ -15,7 +15,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "ml",
     value: "16px",
   },
@@ -26,7 +26,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "hasBorder",
     value: true,
   },
@@ -37,7 +37,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "hasBorder",
     value: false,
   },
@@ -48,7 +48,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     prop: "newProp",
     value: "value",
   },
@@ -59,7 +59,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "ml",
     value: "2",
   },
@@ -70,7 +70,7 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "hasLink",
     value: "test foo bar",
   },
@@ -81,9 +81,21 @@ defineTest(
   __dirname,
   "add-prop",
   {
-    component: "carbon-react/lib/components/button",
+    importPath: "carbon-react/lib/components/button",
     prop: "info",
     value: "test foo bar",
   },
   "Object"
+);
+
+defineTest(
+  __dirname,
+  "add-prop",
+  {
+    importPath: "carbon-react/lib/components/button",
+    importName: "Button",
+    prop: "import",
+    value: "named",
+  },
+  "NamedImport"
 );

--- a/transforms/add-prop/add-prop.js
+++ b/transforms/add-prop/add-prop.js
@@ -9,9 +9,9 @@ const transformer = (fileInfo, api, options) => {
   registerMethods(j);
   const root = j(fileInfo.source);
 
-  const { component, prop, value } = options;
+  const { importPath, prop, value, importName } = options;
 
-  const result = addAttribute(component, prop, value)(
+  const result = addAttribute(importPath, prop, value, importName)(
     fileInfo,
     api,
     options,

--- a/transforms/builder/addAttribute.js
+++ b/transforms/builder/addAttribute.js
@@ -1,11 +1,13 @@
-const addAttribute = (path, attribute, value) => (
+const addAttribute = (path, attribute, value, importName) => (
   fileInfo,
   api,
   options,
   j,
   root
 ) => {
-  const components = root.findJSXElementsByImport(path);
+  const components = importName
+    ? root.findJSXElementsByNamedImport(path, importName)
+    : root.findJSXElementsByImport(path);
 
   // If the component is not imported, skip this file
   if (components.size() === 0) {

--- a/transforms/builder/finder.js
+++ b/transforms/builder/finder.js
@@ -55,7 +55,8 @@ const finder = (
     ObjectExpressionsLiteralReplacement: ObjectExpressionsLiteralReplacementFn,
     ObjectExpressionsIdentifierReplacement: ObjectExpressionsIdentifierReplacementFn,
     JSXSpreadAttributeIdentifierReplacement: JSXSpreadAttributeIdentifierReplacementFn,
-  }
+  },
+  importName
 ) => (fileInfo, api, options, j, root) => {
   /*
    * <Component prop="" />
@@ -150,7 +151,9 @@ const finder = (
     return didUpdate;
   };
 
-  const components = root.findJSXElementsByImport(path);
+  const components = importName
+    ? root.findJSXElementsByNamedImport(path, importName)
+    : root.findJSXElementsByImport(path);
 
   if (components.size() === 0) {
     // If the component is not imported, skip this file

--- a/transforms/builder/removeAttribute.js
+++ b/transforms/builder/removeAttribute.js
@@ -1,26 +1,31 @@
 import finder from "./finder";
 
-const removeAttribute = (path, attribute) =>
-  finder(path, attribute, {
-    JSXAttributeReplacement: (attributes) => {
-      attributes.remove();
-      return true;
-    },
+const removeAttribute = (path, attribute, importName) =>
+  finder(
+    path,
+    attribute,
+    {
+      JSXAttributeReplacement: (attributes) => {
+        attributes.remove();
+        return true;
+      },
 
-    ObjectExpressionsLiteralReplacement: (results, j) => {
-      results.remove();
-      return true;
-    },
+      ObjectExpressionsLiteralReplacement: (results, j) => {
+        results.remove();
+        return true;
+      },
 
-    ObjectExpressionsIdentifierReplacement: (results, j) => {
-      results.remove();
-      return true;
-    },
+      ObjectExpressionsIdentifierReplacement: (results, j) => {
+        results.remove();
+        return true;
+      },
 
-    JSXSpreadAttributeIdentifierReplacement: (results, j) => {
-      results.remove();
-      return true;
+      JSXSpreadAttributeIdentifierReplacement: (results, j) => {
+        results.remove();
+        return true;
+      },
     },
-  });
+    importName
+  );
 
 export default removeAttribute;

--- a/transforms/builder/renameAttribute.js
+++ b/transforms/builder/renameAttribute.js
@@ -1,31 +1,36 @@
 import finder from "./finder";
 
-const renameAttribute = (path, attribute, replacement) =>
-  finder(path, attribute, {
-    JSXAttributeReplacement: (attributes, j) => {
-      attributes.forEach((nodePath) => {
-        j(nodePath)
-          .find(j.JSXIdentifier)
-          .replaceWith(j.jsxIdentifier(replacement));
-      });
-      return true;
-    },
+const renameAttribute = (path, attribute, replacement, importName) =>
+  finder(
+    path,
+    attribute,
+    {
+      JSXAttributeReplacement: (attributes, j) => {
+        attributes.forEach((nodePath) => {
+          j(nodePath)
+            .find(j.JSXIdentifier)
+            .replaceWith(j.jsxIdentifier(replacement));
+        });
+        return true;
+      },
 
-    ObjectExpressionsLiteralReplacement: (results, j) => {
-      results.get("key").replace(j.identifier(replacement));
-      return true;
-    },
+      ObjectExpressionsLiteralReplacement: (results, j) => {
+        results.get("key").replace(j.identifier(replacement));
+        return true;
+      },
 
-    ObjectExpressionsIdentifierReplacement: (results, j) => {
-      results.get("key").replace(j.identifier(replacement));
-      results.get().node.shorthand = false;
-      return true;
-    },
+      ObjectExpressionsIdentifierReplacement: (results, j) => {
+        results.get("key").replace(j.identifier(replacement));
+        results.get().node.shorthand = false;
+        return true;
+      },
 
-    JSXSpreadAttributeIdentifierReplacement: (results, j) => {
-      results.get("key").replace(j.identifier(replacement));
-      return true;
+      JSXSpreadAttributeIdentifierReplacement: (results, j) => {
+        results.get("key").replace(j.identifier(replacement));
+        return true;
+      },
     },
-  });
+    importName
+  );
 
 export default renameAttribute;

--- a/transforms/builder/replaceAttributeValue.js
+++ b/transforms/builder/replaceAttributeValue.js
@@ -95,51 +95,63 @@ const JSXExpressionReplacement = (j, attribute, oldValue, newValue) => {
   return didUpdate;
 };
 
-const replaceAttributeValue = (path, attribute, oldValue, newValue) =>
-  finder(path, attribute, {
-    JSXAttributeReplacement: (attributes, j) => {
-      const selectedAttribute = attributes.last();
+const replaceAttributeValue = (
+  path,
+  attribute,
+  oldValue,
+  newValue,
+  importName
+) =>
+  finder(
+    path,
+    attribute,
+    {
+      JSXAttributeReplacement: (attributes, j) => {
+        const selectedAttribute = attributes.last();
 
-      let didUpdate =
-        LiteralReplacement(
-          j,
-          selectedAttribute,
-          attribute,
-          oldValue,
-          newValue
-        ) || JSXExpressionReplacement(j, selectedAttribute, oldValue, newValue);
-      return didUpdate;
-    },
+        let didUpdate =
+          LiteralReplacement(
+            j,
+            selectedAttribute,
+            attribute,
+            oldValue,
+            newValue
+          ) ||
+          JSXExpressionReplacement(j, selectedAttribute, oldValue, newValue);
+        return didUpdate;
+      },
 
-    ObjectExpressionsLiteralReplacement: (results, j) => {
-      let didUpdate = false;
-      const value = results.get("value");
-      if (value.value.value === oldValue) {
-        value.replace(j.literal(newValue));
-        didUpdate = true;
-      }
-      return didUpdate;
-    },
+      ObjectExpressionsLiteralReplacement: (results, j) => {
+        let didUpdate = false;
+        const value = results.get("value");
+        if (value.value.value === oldValue) {
+          value.replace(j.literal(newValue));
+          didUpdate = true;
+        }
+        return didUpdate;
+      },
 
-    ObjectExpressionsIdentifierReplacement: (results, j) => {
-      let didUpdate = false;
-      const value = results.get("value");
-      if (value.value.value === oldValue) {
-        value.replace(j.literal(newValue));
-        didUpdate = true;
-      }
-      return didUpdate;
-    },
+      ObjectExpressionsIdentifierReplacement: (results, j) => {
+        let didUpdate = false;
+        const value = results.get("value");
+        if (value.value.value === oldValue) {
+          value.replace(j.literal(newValue));
+          didUpdate = true;
+        }
+        return didUpdate;
+      },
 
-    JSXSpreadAttributeIdentifierReplacement: (results, j) => {
-      let didUpdate = false;
-      const value = results.get("value");
-      if (value.value.value === oldValue) {
-        value.replace(j.literal(newValue));
-        didUpdate = true;
-      }
-      return didUpdate;
+      JSXSpreadAttributeIdentifierReplacement: (results, j) => {
+        let didUpdate = false;
+        const value = results.get("value");
+        if (value.value.value === oldValue) {
+          value.replace(j.literal(newValue));
+          didUpdate = true;
+        }
+        return didUpdate;
+      },
     },
-  });
+    importName
+  );
 
 export default replaceAttributeValue;

--- a/transforms/remove-prop/README.md
+++ b/transforms/remove-prop/README.md
@@ -41,15 +41,26 @@ If there is a pattern that you use that is not transformed, please file a featur
 
 ## Usage
 
+### Components imported as a default import:
+
 `npx carbon-codemod remove-prop <target> <component-import-path> <prop>`
 
-### Example
+`npx carbon-codemod remove-prop src carbon-react/lib/components/button oldProp`
+
+### Components imported as a named import:
+
+`npx carbon-codemod remove-prop <target> <component-import-path> <prop> -i <component-import-name>`
+
+`npx carbon-codemod remove-prop src carbon-react/lib/components/accordion oldProp -i Accordion`
+
+## Example
 
 `npx carbon-codemod remove-prop src carbon-react/lib/components/button buttonType`
 
 ```js
 import Button from "carbon-react/lib/components/button";
 ```
+
 ```diff
 - <Button buttonType="primary>Button</Button>
 + <Button>Button</Button>

--- a/transforms/remove-prop/__testfixtures__/NamedImport.input.js
+++ b/transforms/remove-prop/__testfixtures__/NamedImport.input.js
@@ -1,0 +1,10 @@
+import { Component } from "carbon-react/lib/components/component";
+export default () => <Component prop="info" />;
+export const withProps = () => <Component prop="info" title="Example" />;
+const prop = "info";
+export const asVariable = () => <Component prop={prop} />;
+const props = { prop: "info", title: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "info", title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, title: "Example" }} />;

--- a/transforms/remove-prop/__testfixtures__/NamedImport.output.js
+++ b/transforms/remove-prop/__testfixtures__/NamedImport.output.js
@@ -1,0 +1,18 @@
+import { Component } from "carbon-react/lib/components/component";
+export default () => <Component />;
+export const withProps = () => <Component title="Example" />;
+const prop = "info";
+export const asVariable = () => <Component />;
+const props = {
+  title: "Example"
+}
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{
+  title: "Example"
+}} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{
+  title: "Example"
+}} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{
+  title: "Example"
+}} />;

--- a/transforms/remove-prop/__tests__/remove-prop.js
+++ b/transforms/remove-prop/__tests__/remove-prop.js
@@ -4,7 +4,7 @@ defineTest(
   __dirname,
   "remove-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     prop: "prop",
   },
   "Basic"
@@ -14,7 +14,18 @@ defineTest(
   __dirname,
   "remove-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
+    importName: "Component",
+    prop: "prop",
+  },
+  "NamedImport"
+);
+
+defineTest(
+  __dirname,
+  "remove-prop",
+  {
+    importPath: "carbon-react/lib/components/component",
     prop: "prop",
   },
   "Bug"
@@ -24,7 +35,7 @@ defineTest(
   __dirname,
   "remove-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     prop: "prop",
   },
   "NoImport"

--- a/transforms/remove-prop/remove-prop.js
+++ b/transforms/remove-prop/remove-prop.js
@@ -9,9 +9,9 @@ const transformer = (fileInfo, api, options) => {
   registerMethods(j);
   const root = j(fileInfo.source);
 
-  const { component, prop } = options;
+  const { importPath, prop, importName } = options;
 
-  const result = removeAttribute(component, prop)(
+  const result = removeAttribute(importPath, prop, importName)(
     fileInfo,
     api,
     options,

--- a/transforms/rename-prop/README.md
+++ b/transforms/rename-prop/README.md
@@ -41,15 +41,26 @@ If there is a pattern that you use that is not transformed, please file a featur
 
 ## Usage
 
+### Components imported as a default import:
+
 `npx carbon-codemod rename-prop <target> <component-import-path> <old-prop> <new-prop>`
 
-### Example
+`npx carbon-codemod rename-prop src carbon-react/lib/components/button oldProp newProp`
+
+### Components imported as a named import:
+
+`npx carbon-codemod rename-prop <target> <component-import-path> <old-prop> <new-prop> -i <component-import-name>`
+
+`npx carbon-codemod rename-prop src carbon-react/lib/components/accordion oldProp newProp -i Accordion`
+
+## Example
 
 `npx carbon-codemod rename-prop src carbon-react/lib/components/button buttonType variant`
 
 ```js
 import Button from "carbon-react/lib/components/button";
 ```
+
 ```diff
 - <Button buttonType="primary>Button</Button>
 + <Button variant="primary">Button</Button>

--- a/transforms/rename-prop/__testfixtures__/NamedImport.input.js
+++ b/transforms/rename-prop/__testfixtures__/NamedImport.input.js
@@ -1,0 +1,10 @@
+import { Component } from "carbon-react/lib/components/component";
+export default () => <Component old="info" />;
+export const withProps = () => <Component old="info" title="Example" />;
+const old = "info";
+export const asVariable = () => <Component old={old} />;
+const props = { old: "info", title: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ old: "info", title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ old, title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ old: old, title: "Example" }} />;

--- a/transforms/rename-prop/__testfixtures__/NamedImport.output.js
+++ b/transforms/rename-prop/__testfixtures__/NamedImport.output.js
@@ -1,0 +1,10 @@
+import { Component } from "carbon-react/lib/components/component";
+export default () => <Component replacement="info" />;
+export const withProps = () => <Component replacement="info" title="Example" />;
+const old = "info";
+export const asVariable = () => <Component replacement={old} />;
+const props = { replacement: "info", title: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ replacement: "info", title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ replacement: old, title: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ replacement: old, title: "Example" }} />;

--- a/transforms/rename-prop/__tests__/rename-prop.js
+++ b/transforms/rename-prop/__tests__/rename-prop.js
@@ -4,7 +4,7 @@ defineTest(
   __dirname,
   "rename-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     old: "old",
     replacement: "replacement",
   },
@@ -15,7 +15,19 @@ defineTest(
   __dirname,
   "rename-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
+    importName: "Component",
+    old: "old",
+    replacement: "replacement",
+  },
+  "NamedImport"
+);
+
+defineTest(
+  __dirname,
+  "rename-prop",
+  {
+    importPath: "carbon-react/lib/components/component",
     old: "old",
     replacement: "replacement",
   },
@@ -26,7 +38,7 @@ defineTest(
   __dirname,
   "rename-prop",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     old: "old",
     replacement: "replacement",
   },

--- a/transforms/rename-prop/rename-prop.js
+++ b/transforms/rename-prop/rename-prop.js
@@ -9,9 +9,9 @@ const transformer = (fileInfo, api, options) => {
   registerMethods(j);
   const root = j(fileInfo.source);
 
-  const { component, old, replacement } = options;
+  const { importPath, old, replacement, importName } = options;
 
-  const result = renameAttribute(component, old, replacement)(
+  const result = renameAttribute(importPath, old, replacement, importName)(
     fileInfo,
     api,
     options,

--- a/transforms/replace-prop-value/README.md
+++ b/transforms/replace-prop-value/README.md
@@ -5,6 +5,7 @@ This universal codemod provides possibility to replace any prop value in any com
 ```js
 import Component from "carbon-react/lib/components/component";
 ```
+
 ```diff
 - <Component prop="something" />
 + <Component prop="something different" />
@@ -23,13 +24,13 @@ It's likely that props might be assigned in a different manners, therefore this 
 ```js
 const value = "something";
 
-<Component prop={value} />
+<Component prop={value} />;
 ```
 
 ```js
 const props = { prop: "something" };
 
-<Component {...props} />
+<Component {...props} />;
 ```
 
 ```js
@@ -39,26 +40,37 @@ const props = { prop: "something" };
 ```js
 const prop = "something";
 
-<Component {...{ prop }} />
+<Component {...{ prop }} />;
 ```
 
 ```js
 const value = "something";
 
-<Component {...{ prop: value }} />
+<Component {...{ prop: value }} />;
 ```
 
 If there is a pattern that you use that is not transformed, please file a feature request.
 
 ## Usage
 
+### Components imported as a default import:
+
 `npx carbon-codemod replace-prop-value <target> <component-import-path> <prop> <old-value> <new-value>`
 
-Note: To use a numeric value as a string as `old-value` or `new-value`, format it as `\"string\"` on the command line, i.e.: 
+`npx carbon-codemod replace-prop-value src carbon-react/lib/components/button prop oldValue newValue`
+
+### Components imported as a named import:
+
+`npx carbon-codemod replace-prop-value <target> <component-import-path> <prop> <old-value> <new-value> -i <component-import-name>`
+
+`npx carbon-codemod replace-prop-value src carbon-react/lib/components/accordion prop oldValue newValue -i Accordion`
+
+Note: To use a numeric value as a string as `old-value` or `new-value`, format it as `\"string\"` on the command line, i.e.:
 
 `npx carbon-codemod replace-prop-value src carbon-react/lib/components/tile padding \"2\" \"3\"`
 
 ### Examples
 
 `npx carbon-codemod replace-prop-value src carbon-react/lib/components/tile padding 2 4`
+
 `npx carbon-codemod replace-prop-value src carbon-react/lib/components/tile padding XL 10px`

--- a/transforms/replace-prop-value/__testfixtures__/NamedImport.input.js
+++ b/transforms/replace-prop-value/__testfixtures__/NamedImport.input.js
@@ -1,0 +1,13 @@
+import { Component } from "carbon-react/lib/components/component";
+
+export default () => <Component prop="oldString" />;
+export const withProps = () => <Component otherProp="Example" prop="oldString" />
+
+const prop = "oldString";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "oldString", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "oldString", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__testfixtures__/NamedImport.output.js
+++ b/transforms/replace-prop-value/__testfixtures__/NamedImport.output.js
@@ -1,0 +1,13 @@
+import { Component } from "carbon-react/lib/components/component";
+
+export default () => <Component prop="newString" />;
+export const withProps = () => <Component otherProp="Example" prop="newString" />
+
+const prop = "newString";
+export const asVariable = () => <Component prop={prop} />;
+
+const props = { prop: "newString", otherProp: "Example" }
+export const spread = () => <Component {...props} />;
+export const ObjectExpressionsLiteralReplacement = () => <Component {...{ prop: "newString", otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement1 = () => <Component {...{ prop, otherProp: "Example" }} />;
+export const ObjectExpressionsIdentifierReplacement2 = () => <Component {...{ prop: prop, otherProp: "Example" }} />;

--- a/transforms/replace-prop-value/__tests__/replace-prop-value.js
+++ b/transforms/replace-prop-value/__tests__/replace-prop-value.js
@@ -4,7 +4,7 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: "test",
     newValue: 3,
@@ -16,7 +16,7 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: "oldString",
     newValue: "newString",
@@ -28,7 +28,20 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
+    importName: "Component",
+    attribute: "prop",
+    oldValue: "oldString",
+    newValue: "newString",
+  },
+  "NamedImport"
+);
+
+defineTest(
+  __dirname,
+  "replace-prop-value",
+  {
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: "oldString",
     newValue: 2,
@@ -40,7 +53,7 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: 3,
     newValue: "newString",
@@ -52,7 +65,7 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: 3,
     newValue: 2,
@@ -64,7 +77,7 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: "3",
     newValue: "newValue",
@@ -76,7 +89,7 @@ defineTest(
   __dirname,
   "replace-prop-value",
   {
-    component: "carbon-react/lib/components/component",
+    importPath: "carbon-react/lib/components/component",
     attribute: "prop",
     oldValue: "oldValue",
     newValue: "2",

--- a/transforms/replace-prop-value/replace-prop-value.js
+++ b/transforms/replace-prop-value/replace-prop-value.js
@@ -9,13 +9,14 @@ const transformer = (fileInfo, api, options) => {
   registerMethods(j);
   const root = j(fileInfo.source);
 
-  const { component, attribute, oldValue, newValue } = options;
+  const { importPath, attribute, oldValue, newValue, importName } = options;
 
   const result = replaceAttributeValue(
-    component,
+    importPath,
     attribute,
     oldValue,
-    newValue
+    newValue,
+    importName
   )(fileInfo, api, options, j, root);
 
   if (result) {


### PR DESCRIPTION
### Proposed behaviour

This PR adds support for components that use named exports for all the universal codemods.

If component that the given codemod is meant to be run on is imported using the named import, simply add optional flag `-i ComponentName` to the command.

### Current behaviour

Only possible to run universal codemods on components using default export.

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

