### PR TITLE
ci: Add codeql scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: CodeQL config
+
+paths:
+  - bin
+  - transforms
+paths-ignore:
+  - "**/__tests__/**"
+  - "**/__testfixtures__/**"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: javascript
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# carbon-codemod [!build](https://github.com/Sage/carbon-codemod/tree/master/.github/workflows/semantic-release.yml?branch=master) [![npm](https://img.shields.io/npm/v/carbon-codemod.svg)](https://www.npmjs.com/package/carbon-codemod)
+# carbon-codemod [![npm](https://img.shields.io/npm/v/carbon-codemod.svg)](https://www.npmjs.com/package/carbon-codemod)
 
 This is a collection of codemods that help you upgrade to a new version of `carbon-react`.
 The release notes of `carbon-react` will indicate which codemod you should use.

--- a/package.json
+++ b/package.json
@@ -65,7 +65,12 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       "@semantic-release/npm",
-      "@semantic-release/git",
+      [
+        "@semantic-release/git",
+        {
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+        }
+      ],
       "@semantic-release/github"
     ]
   }


### PR DESCRIPTION
### Proposed behaviour

- Change the semantic release commit messages to be the same as Carbon.
- Add CodeQL scanning CI
- Remove the build status badge on the readme

### Current behaviour


### Checklist

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Readme updated

### Additional context

### Testing instructions
