### PR TITLE
feat: add replace-collapsible-pod-with-accordion codemod

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -256,6 +256,13 @@ Example
       });
     });
 
+  program
+    .command(
+      "replace-collapsible-pod-with-accordion <target>"
+    )
+    .description("replaces deprecated collapse Pod prop with the Accordion Component")
+    .action((target, command) => runTransform(target, command, program));
+
   program.on("command:*", function () {
     console.error(
       "Invalid command: %s\nSee --help for a list of available commands.",

--- a/transforms/replace-collapsible-pod-with-accordion/README.md
+++ b/transforms/replace-collapsible-pod-with-accordion/README.md
@@ -1,0 +1,55 @@
+# replace-collapsible-pod-with-accordion
+
+The `collapsed` prop of the Pod component has been deprecated in favour of placing an Accordion inside the Pod Content. This codemod removes all `collapsed` prop instances and places an `Accordion` with the `expanded` prop inside the Pod Content. Title and subtitle props will be also moved to replicate previous functionality.
+
+```diff
+import Pod from "carbon-react/lib/components/pod";
+
++ import { Accordion } from "carbon-react/lib/components/accordion";
+
+- <Pod title="Title" subtitle="subtitle" collapsed>pod content</Pod>
++ <Pod><Accordion borders="none" title="Title" subtitle="subtitle">pod content</Accordion></Pod>
+```
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Pod collapsed title="Title" subtitle="subtitle" />
+```
+
+```js
+const collapsed = true;
+const title = "Title";
+
+<Pod collapsed={collapsed} title={title} subtitle={subtitle} />;
+```
+
+```js
+const props = {
+  collapsed: true,
+  title: "Title",
+  subtitle: "subtitle"
+};
+
+<Pod {...props} />;
+```
+
+```js
+<Pod {...{ collapsed: true, title: "Title", subtitle: "subtitle" }} />
+```
+
+```js
+const value = true;
+
+<Pod {...{ collapsed: value }} />;
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod replace-collapsible-pod-with-accordion <target>`
+
+### Example
+
+`npx carbon-codemod replace-collapsible-pod-with-accordion src`

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/Basic.input.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/Basic.input.js
@@ -1,0 +1,15 @@
+import Pod from "carbon-react/lib/components/pod";
+
+const Basic = ({ children }) => <Pod title="Title" subtitle="subtitle" collapsed>{children}</Pod>;
+
+const WithBooleanValue = ({ children }) => <Pod title="Title" subtitle="subtitle" collapsed={true}>{children}</Pod>;
+
+const WithCollapsedBasedOnProp = ({ children, closed }) => <Pod title="Title" subtitle="subtitle" collapsed={closed}>{children}</Pod>;
+
+const WithCollapsedSetToFalse = ({ children }) => <Pod title="Title" subtitle="subtitle" collapsed={false}>{children}</Pod>;
+
+const WithTitlePassed = ({ children, title }) => <Pod title={title} subtitle="subtitle" collapsed>{children}</Pod>;
+
+const WithoutTitleProp = ({ children }) => <Pod collapsed>{children}</Pod>;
+
+const WithoutCollapsedProp = ({ children }) => <Pod title="Title" subtitle="subtitle">{children}</Pod>;

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/Basic.output.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/Basic.output.js
@@ -1,0 +1,17 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const Basic = ({ children }) => <Pod><Accordion borders="none" title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+
+const WithBooleanValue = ({ children }) => <Pod><Accordion borders="none" title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+
+const WithCollapsedBasedOnProp = ({ children, closed }) => <Pod><Accordion borders="none" expanded={!closed} title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+
+const WithCollapsedSetToFalse = ({ children }) => <Pod><Accordion borders="none" expanded title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+
+const WithTitlePassed = ({ children, title }) => <Pod><Accordion borders="none" title={title} subtitle="subtitle">{children}</Accordion></Pod>;
+
+const WithoutTitleProp = ({ children }) => <Pod><Accordion borders="none">{children}</Accordion></Pod>;
+
+const WithoutCollapsedProp = ({ children }) => <Pod title="Title" subtitle="subtitle">{children}</Pod>;

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/NoImport.input.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Not a Pod
+import NotPod from "carbon-react/lib/components/NotPod";
+export default () => <NotPod />;

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithAccordion.input.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithAccordion.input.js
@@ -1,0 +1,9 @@
+import Pod from "carbon-react/lib/components/pod";
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithAccordion = ({ children }) => {
+  return <>
+    <Pod title="Title" collapsed>{children}</Pod>
+    <Accordion>accordion content</Accordion>
+  </>;
+};

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithAccordion.output.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithAccordion.output.js
@@ -1,0 +1,9 @@
+import Pod from "carbon-react/lib/components/pod";
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithAccordion = ({ children }) => {
+  return <>
+    <Pod><Accordion borders="none" title="Title">{children}</Accordion></Pod>
+    <Accordion>accordion content</Accordion>
+  </>;
+};

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithObjectPropsInOpeningElement.input.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithObjectPropsInOpeningElement.input.js
@@ -1,0 +1,17 @@
+import Pod from "carbon-react/lib/components/pod";
+
+const WithObjectPropsInOpeningElement = ({ children, podTitle, podSubtitle, podCollapsed }) => {
+  return <Pod {...{title: podTitle, subtitle: podSubtitle, collapsed: podCollapsed}}>{children}</Pod>;
+};
+
+const WithCollapsedSetToTrue = ({ children, subtitle }) => {
+  return <Pod {...{title: "Title", subtitle, collapsed: true }}>{children}</Pod>;
+};
+
+const WithPropsPassedAsShorthand = ({ children, title, subtitle, collapsed }) => {
+  return <Pod {...{title, subtitle, collapsed}}>{children}</Pod>;
+};
+
+const WithPropsPassedWithoutTitle = ({ children, subtitle, collapsed }) => {
+  return <Pod {...{subtitle, collapsed}}>{children}</Pod>;
+};

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithObjectPropsInOpeningElement.output.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithObjectPropsInOpeningElement.output.js
@@ -1,0 +1,25 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithObjectPropsInOpeningElement = ({ children, podTitle, podSubtitle, podCollapsed }) => {
+  return (
+    <Pod {...{}}><Accordion
+        borders="none"
+        expanded={!podCollapsed}
+        title={podTitle}
+        subtitle={podSubtitle}>{children}</Accordion></Pod>
+  );
+};
+
+const WithCollapsedSetToTrue = ({ children, subtitle }) => {
+  return <Pod {...{}}><Accordion borders="none" title="Title" subtitle={subtitle}>{children}</Accordion></Pod>;
+};
+
+const WithPropsPassedAsShorthand = ({ children, title, subtitle, collapsed }) => {
+  return <Pod {...{}}><Accordion borders="none" expanded={!collapsed} title={title} subtitle={subtitle}>{children}</Accordion></Pod>;
+};
+
+const WithPropsPassedWithoutTitle = ({ children, subtitle, collapsed }) => {
+  return <Pod {...{}}><Accordion borders="none" expanded={!collapsed} subtitle={subtitle}>{children}</Accordion></Pod>;
+};

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithPropsSpreadFromObject.input.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithPropsSpreadFromObject.input.js
@@ -1,0 +1,62 @@
+import Pod from "carbon-react/lib/components/pod";
+
+const WithPropsSpreadFromObject = ({children, closed}) => {
+  const podProps = {
+    title: "Title",
+    collapsed: closed,
+    subtitle: "subtitle",
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};
+
+const WithTitleAsShorthand = ({children, closed, title}) => {
+  const podProps = {
+    title,
+    collapsed: closed,
+    subtitle: "subtitle",
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};
+
+const WithTitlePassed = ({children, closed, podTitle}) => {
+  const podProps = {
+    title: podTitle,
+    collapsed: closed,
+    subtitle: "subtitle"
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};
+
+const WithMultipleObjectsSpread = ({children, closed, podTitle}) => {
+  const podProps = {
+    collapsed: closed,
+  };
+
+  const other = {
+    subtitle: "subtitle",
+    title: podTitle
+  };
+
+  return <Pod {...podProps} {...other}>{children}</Pod>;
+};
+
+const WithSpreadPropsNoTitle = ({children, closed}) => {
+  const podProps = {
+    collapsed: closed,
+    subtitle: "subtitle",
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};
+
+const WithSpreadPropsNoCollapsed = ({children}) => {
+  const podProps = {
+    title: "Title",
+    subtitle: "subtitle",
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};

--- a/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithPropsSpreadFromObject.output.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__testfixtures__/WithPropsSpreadFromObject.output.js
@@ -1,0 +1,44 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithPropsSpreadFromObject = ({children, closed}) => {
+  const podProps = {};
+
+  return <Pod {...podProps}><Accordion borders="none" expanded={!closed} title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+};
+
+const WithTitleAsShorthand = ({children, closed, title}) => {
+  const podProps = {};
+
+  return <Pod {...podProps}><Accordion borders="none" expanded={!closed} title={title} subtitle="subtitle">{children}</Accordion></Pod>;
+};
+
+const WithTitlePassed = ({children, closed, podTitle}) => {
+  const podProps = {};
+
+  return <Pod {...podProps}><Accordion borders="none" expanded={!closed} title={podTitle} subtitle="subtitle">{children}</Accordion></Pod>;
+};
+
+const WithMultipleObjectsSpread = ({children, closed, podTitle}) => {
+  const podProps = {};
+
+  const other = {};
+
+  return <Pod {...podProps} {...other}><Accordion borders="none" expanded={!closed} title={podTitle} subtitle="subtitle">{children}</Accordion></Pod>;
+};
+
+const WithSpreadPropsNoTitle = ({children, closed}) => {
+  const podProps = {};
+
+  return <Pod {...podProps}><Accordion borders="none" expanded={!closed} subtitle="subtitle">{children}</Accordion></Pod>;
+};
+
+const WithSpreadPropsNoCollapsed = ({children}) => {
+  const podProps = {
+    title: "Title",
+    subtitle: "subtitle",
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};

--- a/transforms/replace-collapsible-pod-with-accordion/__tests__/replace-collapsible-pod-with-accordion.js
+++ b/transforms/replace-collapsible-pod-with-accordion/__tests__/replace-collapsible-pod-with-accordion.js
@@ -1,0 +1,36 @@
+import defineTest from "../../../defineTest";
+
+defineTest(
+  __dirname,
+  "replace-collapsible-pod-with-accordion",
+  null,
+  "Basic"
+);
+
+defineTest(
+  __dirname,
+  "replace-collapsible-pod-with-accordion",
+  null,
+  "NoImport"
+);
+
+defineTest(
+  __dirname,
+  "replace-collapsible-pod-with-accordion",
+  null,
+  "WithAccordion"
+);
+
+defineTest(
+  __dirname,
+  "replace-collapsible-pod-with-accordion",
+  null,
+  "WithObjectPropsInOpeningElement"
+);
+
+defineTest(
+  __dirname,
+  "replace-collapsible-pod-with-accordion",
+  null,
+  "WithPropsSpreadFromObject"
+);

--- a/transforms/replace-collapsible-pod-with-accordion/replace-collapsible-pod-with-accordion.js
+++ b/transforms/replace-collapsible-pod-with-accordion/replace-collapsible-pod-with-accordion.js
@@ -1,0 +1,369 @@
+import {
+  findJSXAttribute,
+  findObjectExpressionsLiteral,
+  findObjectExpressionsIdentifier,
+} from "../builder/finder";
+import registerMethods from "../registerMethods";
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const names = {
+    collapsedProp: "collapsed",
+    titleProp: "title",
+    subtitleProp: "subtitle",
+    expandedProp: "expanded",
+    podComponent: "Pod",
+    accordionComponent: "Accordion",
+  };
+  let podNodes = root.findJSXElements(names.podComponent);
+
+  registerMethods(j);
+
+  if (
+    !podNodes
+      .paths()
+      .some((podNode) => hasCollapsedProp(podNode, names.collapsedProp))
+  ) {
+    return;
+  }
+
+  addAccordionImport(j, root);
+  addAccordion(j, podNodes);
+
+  function addAccordionImport(j, root) {
+    let accordionImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: "carbon-react/lib/components/accordion",
+      },
+    });
+    const podImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: "carbon-react/lib/components/pod",
+      },
+    });
+
+    if (accordionImport.size()) {
+      return;
+    }
+
+    accordionImport = j.importDeclaration(
+      [j.importSpecifier(j.identifier(names.accordionComponent))],
+      j.stringLiteral("carbon-react/lib/components/accordion")
+    );
+
+    podImport.insertAfter(accordionImport);
+  }
+
+  function addAccordion(j, podNodes) {
+    podNodes.forEach((podNode) => {
+      if (!hasCollapsedProp(podNode)) {
+        return;
+      }
+
+      const accordionAttributes = [
+        j.jsxAttribute(j.jsxIdentifier("borders"), j.stringLiteral("none")),
+      ];
+
+      // JSX Attribute Props
+      let collapsedJSXAttributeProp = findJSXAttribute(
+        j,
+        j(podNode),
+        names.collapsedProp
+      );
+
+      if (collapsedJSXAttributeProp.size()) {
+        accordionAttributes.push(
+          getExpandedAttribute(collapsedJSXAttributeProp)
+        );
+        collapsedJSXAttributeProp.remove();
+      }
+
+      const titleJSXAttributeProp = findJSXAttribute(
+        j,
+        j(podNode),
+        names.titleProp
+      );
+
+      if (titleJSXAttributeProp.size()) {
+        accordionAttributes.push(getTitleAttribute(titleJSXAttributeProp, names.titleProp));
+        titleJSXAttributeProp.remove();
+      }
+
+      const subtitleJSXAttributeProp = findJSXAttribute(
+        j,
+        j(podNode),
+        names.subtitleProp
+      );
+
+      if (subtitleJSXAttributeProp.size()) {
+        accordionAttributes.push(getTitleAttribute(subtitleJSXAttributeProp, names.subtitleProp));
+        subtitleJSXAttributeProp.remove();
+      }
+
+      // spread props
+      const spreadAttributeObject = j(podNode).find(j.JSXSpreadAttribute);
+
+      if (spreadAttributeObject.size()) {
+        const typeOfSpreadAttributeObject = spreadAttributeObject.get(
+          "argument",
+          "type"
+        ).value;
+
+        if (typeOfSpreadAttributeObject === "Identifier") {
+          // props spread from an object in declaration scope
+          spreadAttributeObject.forEach((attr) => {
+            const collapsedInDeclarationScope = getPropertyFromDeclarationScope(
+              podNode,
+              attr.value,
+              names.collapsedProp
+            );
+
+            if (collapsedInDeclarationScope.size()) {
+              accordionAttributes.push(
+                getExpandedAttribute(collapsedInDeclarationScope)
+              );
+              collapsedInDeclarationScope.remove();
+            }
+
+            const titleInDeclarationScope = getPropertyFromDeclarationScope(
+              podNode,
+              attr.value,
+              names.titleProp
+            );
+
+            if (titleInDeclarationScope.size()) {
+              accordionAttributes.push(getTitleAttribute(titleInDeclarationScope, names.titleProp));
+              titleInDeclarationScope.remove();
+            }
+
+            const subtitleInDeclarationScope = getPropertyFromDeclarationScope(
+              podNode,
+              attr.value,
+              names.subtitleProp
+            );
+
+            if (subtitleInDeclarationScope.size()) {
+              accordionAttributes.push(getTitleAttribute(subtitleInDeclarationScope, names.subtitleProp));
+              subtitleInDeclarationScope.remove();
+            }
+          });
+        } else {
+          // props spread from an object in the opening element
+          const collapsedAsObjectProp = findObjectExpressionsLiteral(
+            j,
+            spreadAttributeObject,
+            names.collapsedProp
+          );
+
+          if (collapsedAsObjectProp.size()) {
+            accordionAttributes.push(
+              getExpandedPropFromOpeningElementObject(collapsedAsObjectProp)
+            );
+            collapsedAsObjectProp.remove();
+          }
+
+          const titleAsObjectProp = findObjectExpressionsLiteral(
+            j,
+            spreadAttributeObject,
+            names.titleProp
+          );
+
+          if (titleAsObjectProp.size()) {
+            accordionAttributes.push(getTitleAttribute(titleAsObjectProp, names.titleProp));
+            titleAsObjectProp.remove();
+          }
+
+          const subtitleAsObjectProp = findObjectExpressionsLiteral(
+            j,
+            spreadAttributeObject,
+            names.subtitleProp
+          );
+
+          if (subtitleAsObjectProp.size()) {
+            accordionAttributes.push(getTitleAttribute(subtitleAsObjectProp, names.subtitleProp));
+            subtitleAsObjectProp.remove();
+          }
+
+          // props spread as shorthand from an object in opening element
+          const collapsedAsShorthandProp = findObjectExpressionsIdentifier(
+            j,
+            spreadAttributeObject,
+            names.collapsedProp
+          );
+
+          if (collapsedAsShorthandProp.size()) {
+            accordionAttributes.push(j.jsxAttribute(
+                j.jsxIdentifier(names.expandedProp),
+                j.jsxExpressionContainer(j.jsxIdentifier(`!${names.collapsedProp}`))
+              )
+            );
+            collapsedAsShorthandProp.remove();
+          }
+
+          const titleAsShorthandProp = findObjectExpressionsIdentifier(
+            j,
+            spreadAttributeObject,
+            names.titleProp
+          );
+
+          if (titleAsShorthandProp.size()) {
+            accordionAttributes.push(j.jsxAttribute(
+                j.jsxIdentifier(names.titleProp),
+                j.jsxExpressionContainer(j.jsxIdentifier(names.titleProp))
+              )
+            );
+            titleAsShorthandProp.remove();
+          }
+
+          const subtitleAsShorthandProp = findObjectExpressionsIdentifier(
+            j,
+            spreadAttributeObject,
+            names.subtitleProp
+          );
+
+          if (subtitleAsShorthandProp.size()) {
+            accordionAttributes.push(j.jsxAttribute(
+                j.jsxIdentifier(names.subtitleProp),
+                j.jsxExpressionContainer(j.jsxIdentifier(names.subtitleProp))
+              )
+            );
+            subtitleAsShorthandProp.remove();
+          }
+        }
+      }
+
+      const accordionOpeningTag = getAccordionOpeningTag(accordionAttributes.filter(attribute => attribute !== null));
+      const accordionClosingTag = j.jsxClosingElement(
+        j.jsxIdentifier(names.accordionComponent)
+      );
+
+      podNode.node.children = [
+        accordionOpeningTag,
+        ...podNode.value.children,
+        accordionClosingTag,
+      ];
+    });
+  }
+
+  function getAccordionOpeningTag(accordionAttributes) {
+    return j.jsxOpeningElement(
+      j.jsxIdentifier(names.accordionComponent),
+      accordionAttributes
+    );
+  }
+
+  function getTitleAttribute(titleJSXAttributeProp, propName) {
+    const propValue = titleJSXAttributeProp.get("value").value;
+    const isValueLiteral = propValue.type === "Literal";
+
+    if (propValue && propValue.type === "Identifier") {
+      return j.jsxAttribute(
+        j.jsxIdentifier(propName),
+        j.jsxExpressionContainer(j.jsxIdentifier(propValue.name))
+      );
+    }
+
+    return j.jsxAttribute(
+      j.jsxIdentifier(propName),
+      isValueLiteral
+        ? j.stringLiteral(propValue.value)
+        : j.jsxExpressionContainer(
+            j.jsxIdentifier(propValue.expression.name)
+          )
+    );
+  }
+
+  function getExpandedPropFromOpeningElementObject(objectProp) {
+    const objectPropValue = objectProp.get("value").value;
+    if (
+      objectPropValue.type === "Literal" &&
+      (objectPropValue.value === names.collapsedProp ||
+        objectPropValue.value === true)
+    ) {
+      return null;
+    }
+
+    return j.jsxAttribute(
+      j.jsxIdentifier(names.expandedProp),
+      j.jsxExpressionContainer(j.jsxIdentifier(`!${objectPropValue.name}`))
+    );
+  }
+
+  function getExpandedAttribute(collapsedProp) {
+    const propValue = collapsedProp.get("value");
+
+    if (propValue.value && propValue.value.type === "Identifier") {
+      return j.jsxAttribute(
+        j.jsxIdentifier(names.expandedProp),
+        j.jsxExpressionContainer(j.jsxIdentifier(`!${propValue.value.name}`))
+      );
+    }
+
+    if (
+      propValue.value === null ||
+      propValue.value.value === "" ||
+      propValue.value.value === names.collapsedProp ||
+      propValue.value.expression.value === true
+    ) {
+      return null;
+    }
+    
+    if (propValue.value.expression.value === false) {
+      return j.jsxAttribute(j.jsxIdentifier(names.expandedProp));
+    }
+
+    return j.jsxAttribute(
+      j.jsxIdentifier(names.expandedProp),
+      j.jsxExpressionContainer(j.jsxIdentifier(`!${propValue.value.expression.name}`))
+    );
+  }
+
+  function hasCollapsedProp(element) {
+    return element.node.openingElement.attributes.some((attr) => {
+      if (attr.type === "JSXSpreadAttribute") {
+        if (attr.argument.type === "ObjectExpression") {
+          return (
+            j(attr)
+              .find(j.Property, {
+                kind: "init",
+                key: { name: names.collapsedProp },
+              })
+              .size() > 0
+          );
+        }
+
+        const property = getPropertyFromDeclarationScope(
+          element,
+          attr,
+          names.collapsedProp
+        );
+
+        return property.size() > 0;
+      }
+
+      return attr.name.name === names.collapsedProp;
+    });
+  }
+
+  function getPropertyFromDeclarationScope(element, attribute, propName) {
+    const attributeName = attribute.argument.name;
+
+    const declarationScope = j(element).findDeclarationScope(attributeName);
+    const propObject = j(declarationScope.path).find(j.VariableDeclarator, {
+      id: {
+        type: "Identifier",
+        name: attributeName,
+      },
+    });
+
+    return propObject.find(j.Property, {
+      kind: "init",
+      key: { name: propName },
+    });
+  }
+
+  return root.toSource();
+}


### PR DESCRIPTION
### Proposed behaviour

Collapsible Pod functionality is redundant as it could be replicated by placing the Accordion component inside the Pod content.

This codemod will remove the `collpase` prop and place an Accordion inside the Pod content. The `title` prop will also be moved inside the Accordion.

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated
