### PR TITLE
feat: add move-pod-description-to-content codemod

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -263,6 +263,13 @@ Example
     .description("replaces deprecated collapse Pod prop with the Accordion Component")
     .action((target, command) => runTransform(target, command, program));
 
+  program
+    .command(
+      "move-pod-description-to-content <target>"
+    )
+    .description("removes deprecated description Pod prop and places it's value as part of the Pod content")
+    .action((target, command) => runTransform(target, command, program));
+  
   program.on("command:*", function () {
     console.error(
       "Invalid command: %s\nSee --help for a list of available commands.",

--- a/transforms/move-pod-description-to-content/README.md
+++ b/transforms/move-pod-description-to-content/README.md
@@ -1,0 +1,61 @@
+# move-pod-description-to-content
+
+The `description` prop of the `Pod` Component has been deprecated in favour of placing a customized `Typography` Component inside the `Pod` Content. This codemod removes all `description` prop instances and places a `Typography` inside the `Pod` Content or inside the `Accordion` content in case of collapsible `Pod`.
+
+```diff
+import Pod from "carbon-react/lib/components/pod";
+
++ import Typography from "carbon-react/lib/components/typography";
+
+- <Pod title="Title" subtitle="subtitle" description="Description">pod content</Pod>
++ <Pod title="Title" subtitle="subtitle"><Typography as="div" fontSize="13px" lineHeight="normal">Description</Typography>pod content</Pod>
+```
+
+```diff
+import Pod from "carbon-react/lib/components/pod";
+
++ import Typography from "carbon-react/lib/components/typography";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+- <Pod description="Description"><Accordion borders="none" title="Title" subtitle="subtitle">pod content</Accordion></Pod>
++ <Pod><Accordion borders="none" title="Title" subtitle="subtitle"><Typography as="div" fontSize="13px" lineHeight="normal">Description</Typography>pod content</Accordion></Pod>
+```
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Pod description="Description" />
+```
+
+```js
+const description = "Description";
+
+<Pod description={description} />;
+```
+
+```js
+const props = { description: "Description" };
+
+<Pod {...props} />;
+```
+
+```js
+<Pod {...{ description: "Description" }} />
+```
+
+```js
+const value = "Description";
+
+<Pod {...{ description: value }} />;
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod move-pod-description-to-content <target>`
+
+### Example
+
+`npx carbon-codemod move-pod-description-to-content src`

--- a/transforms/move-pod-description-to-content/__testfixtures__/Basic.input.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/Basic.input.js
@@ -1,0 +1,13 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const Basic = ({ children }) => <Pod description="Description" title="Title" subtitle="Subtitle">{children}</Pod>;
+
+const BasicWithAccordion = ({ children }) => <Pod description="Description"><Accordion borders="none" title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+
+const WithDescriptionBasedOnProp = ({ children, desc }) => <Pod description={desc} title="Title" subtitle="Subtitle">{children}</Pod>;
+
+const WithDescriptionEmpty = ({ children }) => <Pod description="" title="Title" subtitle="subtitle">{children}</Pod>;
+
+const WithoutDescription = ({ children }) => <Pod title="Title" subtitle="subtitle">{children}</Pod>;

--- a/transforms/move-pod-description-to-content/__testfixtures__/Basic.output.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/Basic.output.js
@@ -1,0 +1,15 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import Typography from "carbon-react/lib/components/typography";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const Basic = ({ children }) => <Pod title="Title" subtitle="Subtitle"><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">Description</Typography>{children}</Pod>;
+
+const BasicWithAccordion = ({ children }) => <Pod><Accordion borders="none" title="Title" subtitle="subtitle"><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">Description</Typography>{children}</Accordion></Pod>;
+
+const WithDescriptionBasedOnProp = ({ children, desc }) => <Pod title="Title" subtitle="Subtitle"><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{desc}</Typography>{children}</Pod>;
+
+const WithDescriptionEmpty = ({ children }) => <Pod title="Title" subtitle="subtitle"><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">""</Typography>{children}</Pod>;
+
+const WithoutDescription = ({ children }) => <Pod title="Title" subtitle="subtitle">{children}</Pod>;

--- a/transforms/move-pod-description-to-content/__testfixtures__/NoImport.input.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/NoImport.input.js
@@ -1,0 +1,3 @@
+// Not a Pod
+import NotPod from "carbon-react/lib/components/NotPod";
+export default () => <NotPod />;

--- a/transforms/move-pod-description-to-content/__testfixtures__/WithObjectPropsInOpeningElement.input.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/WithObjectPropsInOpeningElement.input.js
@@ -1,0 +1,31 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithObjectPropsInOpeningElement = ({ children, podTitle, podSubtitle, desc }) => {
+  return <Pod {...{title: podTitle, subtitle: podSubtitle, description: desc}}>{children}</Pod>;
+};
+
+const WithAccordionAndObjectPropInOpeningElement = ({ children, podTitle, podSubtitle, podCollapsed, desc }) => {
+  return (
+    <Pod {...{description: desc}}><Accordion
+        borders="none"
+        expanded={!podCollapsed}
+        title={podTitle}
+        subtitle={podSubtitle}>{children}</Accordion></Pod>
+  );
+};
+
+const WithPropsPassedAsShorthand = ({ children, title, subtitle, description }) => {
+  return <Pod {...{title, subtitle, description}}>{children}</Pod>;
+};
+
+const WithAccordionAndPropPassedAsShorthand = ({ children, podTitle, podSubtitle, podCollapsed, description }) => {
+  return (
+    <Pod {...{description}}><Accordion
+        borders="none"
+        expanded={!podCollapsed}
+        title={podTitle}
+        subtitle={podSubtitle}>{children}</Accordion></Pod>
+  );
+};

--- a/transforms/move-pod-description-to-content/__testfixtures__/WithObjectPropsInOpeningElement.output.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/WithObjectPropsInOpeningElement.output.js
@@ -1,0 +1,43 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import Typography from "carbon-react/lib/components/typography";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithObjectPropsInOpeningElement = ({ children, podTitle, podSubtitle, desc }) => {
+  return (
+    <Pod {...{
+      title: podTitle,
+      subtitle: podSubtitle
+    }}><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{desc}</Typography>{children}</Pod>
+  );
+};
+
+const WithAccordionAndObjectPropInOpeningElement = ({ children, podTitle, podSubtitle, podCollapsed, desc }) => {
+  return (
+    <Pod {...{}}><Accordion
+        borders="none"
+        expanded={!podCollapsed}
+        title={podTitle}
+        subtitle={podSubtitle}><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{desc}</Typography>{children}</Accordion></Pod>
+  );
+};
+
+const WithPropsPassedAsShorthand = ({ children, title, subtitle, description }) => {
+  return (
+    <Pod {...{
+      title,
+      subtitle
+    }}><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{description}</Typography>{children}</Pod>
+  );
+};
+
+const WithAccordionAndPropPassedAsShorthand = ({ children, podTitle, podSubtitle, podCollapsed, description }) => {
+  return (
+    <Pod {...{}}><Accordion
+        borders="none"
+        expanded={!podCollapsed}
+        title={podTitle}
+        subtitle={podSubtitle}><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{description}</Typography>{children}</Accordion></Pod>
+  );
+};

--- a/transforms/move-pod-description-to-content/__testfixtures__/WithPropsSpreadFromObject.input.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/WithPropsSpreadFromObject.input.js
@@ -1,0 +1,34 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithPropsSpreadFromObject = ({children, desc}) => {
+  const podProps = {
+    title: "Title",
+    description: desc,
+    subtitle: "subtitle",
+  };
+
+  return <Pod {...podProps}>{children}</Pod>;
+};
+
+const WithMultipleObjectsSpreads = ({children, podTitle, desc}) => {
+  const podProps = {
+    description: desc,
+  };
+
+  const other = {
+    subtitle: "subtitle",
+    title: podTitle
+  };
+
+  return <Pod {...podProps} {...other}>{children}</Pod>;
+};
+
+const WithAccordionAndPropsSpreadFromObject = ({children, closed, desc}) => {
+  const podProps = {
+    description: desc,
+  };
+
+  return <Pod {...podProps}><Accordion borders="none" expanded={!closed} title="Title" subtitle="subtitle">{children}</Accordion></Pod>;
+};

--- a/transforms/move-pod-description-to-content/__testfixtures__/WithPropsSpreadFromObject.output.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/WithPropsSpreadFromObject.output.js
@@ -1,0 +1,31 @@
+import Pod from "carbon-react/lib/components/pod";
+
+import Typography from "carbon-react/lib/components/typography";
+
+import { Accordion } from "carbon-react/lib/components/accordion";
+
+const WithPropsSpreadFromObject = ({children, desc}) => {
+  const podProps = {
+    title: "Title",
+    subtitle: "subtitle"
+  };
+
+  return <Pod {...podProps}><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{desc}</Typography>{children}</Pod>;
+};
+
+const WithMultipleObjectsSpreads = ({children, podTitle, desc}) => {
+  const podProps = {};
+
+  const other = {
+    subtitle: "subtitle",
+    title: podTitle
+  };
+
+  return <Pod {...podProps} {...other}><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{desc}</Typography>{children}</Pod>;
+};
+
+const WithAccordionAndPropsSpreadFromObject = ({children, closed, desc}) => {
+  const podProps = {};
+
+  return <Pod {...podProps}><Accordion borders="none" expanded={!closed} title="Title" subtitle="subtitle"><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">{desc}</Typography>{children}</Accordion></Pod>;
+};

--- a/transforms/move-pod-description-to-content/__testfixtures__/WithTypography.input.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/WithTypography.input.js
@@ -1,0 +1,9 @@
+import Pod from "carbon-react/lib/components/pod";
+import Typography from "carbon-react/lib/components/typography";
+
+const WithTypography = ({ children }) => {
+  return <>
+    <Pod description="Description" title="Title">{children}</Pod>
+    <Typography>accordion content</Typography>
+  </>;
+};

--- a/transforms/move-pod-description-to-content/__testfixtures__/WithTypography.output.js
+++ b/transforms/move-pod-description-to-content/__testfixtures__/WithTypography.output.js
@@ -1,0 +1,9 @@
+import Pod from "carbon-react/lib/components/pod";
+import Typography from "carbon-react/lib/components/typography";
+
+const WithTypography = ({ children }) => {
+  return <>
+    <Pod title="Title"><Typography data-element="description" as="div" fontSize="13px" lineHeight="normal">Description</Typography>{children}</Pod>
+    <Typography>accordion content</Typography>
+  </>;
+};

--- a/transforms/move-pod-description-to-content/__tests__/move-pod-description-to-content.js
+++ b/transforms/move-pod-description-to-content/__tests__/move-pod-description-to-content.js
@@ -1,0 +1,36 @@
+import defineTest from "../../../defineTest";
+
+defineTest(
+  __dirname,
+  "move-pod-description-to-content",
+  null,
+  "Basic"
+);
+
+defineTest(
+  __dirname,
+  "move-pod-description-to-content",
+  null,
+  "NoImport"
+);
+
+defineTest(
+  __dirname,
+  "move-pod-description-to-content",
+  null,
+  "WithTypography"
+);
+
+defineTest(
+  __dirname,
+  "move-pod-description-to-content",
+  null,
+  "WithObjectPropsInOpeningElement"
+);
+
+defineTest(
+  __dirname,
+  "move-pod-description-to-content",
+  null,
+  "WithPropsSpreadFromObject"
+);

--- a/transforms/move-pod-description-to-content/move-pod-description-to-content.js
+++ b/transforms/move-pod-description-to-content/move-pod-description-to-content.js
@@ -1,0 +1,218 @@
+import {
+  findJSXAttribute,
+  findObjectExpressionsLiteral,
+  findObjectExpressionsIdentifier,
+} from "../builder/finder";
+import registerMethods from "../registerMethods";
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const names = {
+    collapsedProp: "collapsed",
+    expandedProp: "expanded",
+    podComponent: "Pod",
+    accordionComponent: "Accordion",
+    typographyComponent: "Typography",
+    descriptionProp: "description",
+  };
+  let podNodes = root.findJSXElements(names.podComponent);
+
+  registerMethods(j);
+
+  if (
+    !podNodes
+      .paths()
+      .some((podNode) => hasDescriptionProp(podNode, names.descriptionProp))
+  ) {
+    return;
+  }
+
+  addTypographyImport(j, root);
+
+  podNodes.forEach((podNode) => {
+    if (!hasDescriptionProp(podNode)) {
+      return;
+    }
+    let accordionNode = j(podNode).findJSXElements(names.accordionComponent);
+
+    let descriptionContent;
+
+    // JSX Attribute Props
+    let descriptionJSXAttributeProp = findJSXAttribute(
+      j,
+      j(podNode),
+      names.descriptionProp
+    );
+
+    if (descriptionJSXAttributeProp.size()) {
+      descriptionContent = getDescriptionContent(descriptionJSXAttributeProp);
+      descriptionJSXAttributeProp.remove();
+    }
+
+    // spread props
+    const spreadAttributeObject = j(podNode).find(j.JSXSpreadAttribute);
+
+    if (spreadAttributeObject.size()) {
+      const typeOfSpreadAttributeObject = spreadAttributeObject.get(
+        "argument",
+        "type"
+      ).value;
+
+      if (typeOfSpreadAttributeObject === "Identifier") {
+        // props spread from an object in declaration scope
+        spreadAttributeObject.forEach((attr) => {
+          const descriptionInDeclarationScope = getPropertyFromDeclarationScope(
+            podNode,
+            attr.value,
+            names.descriptionProp
+          );
+
+          if (descriptionInDeclarationScope.size()) {
+            descriptionContent = getDescriptionContent(descriptionInDeclarationScope);
+            descriptionInDeclarationScope.remove();
+          }
+        });
+      } else {
+        const descriptionAsObjectProp = findObjectExpressionsLiteral(
+          j,
+          spreadAttributeObject,
+          names.descriptionProp
+        );
+
+        if (descriptionAsObjectProp.size()) {
+          descriptionContent = getDescriptionContent(descriptionAsObjectProp);
+          descriptionAsObjectProp.remove();
+        }
+
+        const descriptionAsShorthandProp = findObjectExpressionsIdentifier(
+          j,
+          spreadAttributeObject,
+          names.descriptionProp
+        );
+
+        if (descriptionAsShorthandProp.size()) {
+          descriptionContent = getDescriptionContent(descriptionAsShorthandProp);
+          descriptionAsShorthandProp.remove();
+        }
+      }
+    }
+
+    const descriptionOpeningTag = getDescriptionOpeningTag();
+    const descriptionClosingTag = j.jsxClosingElement(
+      j.jsxIdentifier(names.typographyComponent)
+    );
+
+    if (accordionNode.size()) {
+      accordionNode.paths()[0].value.children = [
+        descriptionOpeningTag,
+        descriptionContent,
+        descriptionClosingTag,
+        ...accordionNode.paths()[0].value.children,
+      ];
+    } else {    
+      podNode.node.children = [
+        descriptionOpeningTag,
+        descriptionContent,
+        descriptionClosingTag,
+        ...podNode.value.children,
+      ];
+    }
+  });
+
+  function addTypographyImport(j, root) {
+    let typographyImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: "carbon-react/lib/components/typography",
+      },
+    });
+    const podImport = root.find(j.ImportDeclaration, {
+      source: {
+        type: "Literal",
+        value: "carbon-react/lib/components/pod",
+      },
+    });
+
+    if (typographyImport.size()) {
+      return;
+    }
+
+    typographyImport = j.importDeclaration(
+      [j.importDefaultSpecifier(j.identifier(names.typographyComponent))],
+      j.stringLiteral("carbon-react/lib/components/typography")
+    );
+
+    podImport.insertAfter(typographyImport);
+  }
+
+  function getDescriptionOpeningTag() {
+    return j.jsxOpeningElement(j.jsxIdentifier(names.typographyComponent), [
+      j.jsxAttribute(j.jsxIdentifier("data-element"), j.stringLiteral("description")),
+      j.jsxAttribute(j.jsxIdentifier("as"), j.stringLiteral("div")),
+      j.jsxAttribute(j.jsxIdentifier("fontSize"), j.stringLiteral("13px")),
+      j.jsxAttribute(j.jsxIdentifier("lineHeight"), j.stringLiteral("normal")),
+    ]);
+  }
+
+  function getDescriptionContent(descriptionJSXAttributeProp) {
+    const propValue = descriptionJSXAttributeProp.get("value").value;
+    const isValueLiteral = propValue.type === "Literal";
+
+    if (propValue && propValue.type === "Identifier") {
+      return j.jsxExpressionContainer(j.jsxIdentifier(propValue.name));
+    }
+
+    return isValueLiteral
+        ? j.stringLiteral(propValue.value)
+        : j.jsxExpressionContainer(
+            j.jsxIdentifier(propValue.expression.name)
+          );
+  }
+
+  function hasDescriptionProp(element) {
+    return element.node.openingElement.attributes.some((attr) => {
+      if (attr.type === "JSXSpreadAttribute") {
+        if (attr.argument.type === "ObjectExpression") {
+          return (
+            j(attr)
+              .find(j.Property, {
+                kind: "init",
+                key: { name: names.descriptionProp },
+              })
+              .size() > 0
+          );
+        }
+
+        const property = getPropertyFromDeclarationScope(
+          element,
+          attr,
+          names.descriptionProp
+        );
+
+        return property.size() > 0;
+      }
+
+      return attr.name.name === names.descriptionProp;
+    });
+  }
+
+  function getPropertyFromDeclarationScope(element, attribute, propName) {
+    const attributeName = attribute.argument.name;
+
+    const declarationScope = j(element).findDeclarationScope(attributeName);
+    const propObject = j(declarationScope.path).find(j.VariableDeclarator, {
+      id: {
+        type: "Identifier",
+        name: attributeName,
+      },
+    });
+
+    return propObject.find(j.Property, {
+      kind: "init",
+      key: { name: propName },
+    });
+  }
+
+  return root.toSource();
+}


### PR DESCRIPTION
Description functionality in Pod is redundant as it could be replicated by placing the Typography component inside the Pod content.

This codemod will remove the `description` prop and place a Typography component with this prop text inside the Pod content.

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
