### PR TITLE
feat: add replace-row-column-with-grid codemod

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -126,6 +126,11 @@ function Cli() {
     .action((target, command) => runTransform(target, command, program));
 
   program
+    .command("replace-row-column-with-grid <target>")
+    .description("Replaces deprecated Row and Column components with Grid component")
+    .action((target, command) => runTransform(target, command, program));
+
+  program
     .command("tile-update-padding-prop <target>")
     .description(
       "Replace padding prop with p prop and change values on tile component"

--- a/transforms/registerMethods.js
+++ b/transforms/registerMethods.js
@@ -118,6 +118,18 @@ export default once((j) => {
       }
       return scope;
     },
+
+    /**
+     * Finds JSX Atribute in the topmost JSXOpeningElement by it's name
+     */
+    findJSXAttribute: function (attributeName) {
+      return this.find(j.JSXOpeningElement).at(0).find(j.JSXAttribute, {
+        name: {
+          type: "JSXIdentifier",
+          name: attributeName,
+        },
+      });
+    },
   });
 
   j.registerMethods(

--- a/transforms/replace-row-column-with-grid/README.md
+++ b/transforms/replace-row-column-with-grid/README.md
@@ -1,0 +1,125 @@
+# replace-row-column-with-grid
+
+The `Row` and `Column` components have been deprecated in favour of `GridContainer` and `GridItem` components respectively. This codemod converts all `Row` and `Column` instances to `GridContainer` and `GridItem`
+
+The codemod will also replace `Row` props with their `GridContainer` equivalents:
+
+- `gutter` will be changed to `gridGap`
+- `columns` will be changed to `gridTemplateColumns`
+
+and `Column` props with their `GridItem` equivalents:
+
+- `columnSpan` will be changed to `gridColumn`
+- `columnOffset` will be removed and the offset added to `gridColumn`
+- `columnAlign` will be changed to `justifySelf`
+
+For column props, only literal values will be changed, e.g.:`prop={3}`, `prop="3"`, `{...{ prop: 3 }}`, `{...{ prop: "3" }}`.
+A codemod to replace these column values passed as variabled would be too complex, so in that case, these props should be addressed manually.
+
+```diff
+- import { Row, Column } from "carbon-react/lib/components/row";
++ import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+- <Row gutter="medium" columns="10" columnDivide>
+-   <Column columns="10" columnAlign="left" columnSpan="3" columnOffset="1">col1</Column>
+-   <Column columns="10" columnAlign="center" columnSpan="2">col2</Column>
+-   <Column columns="10" columnAlign="middle" columnSpan="2">col3</Column>
+-   <Column columns="10" columnAlign="right" columnSpan="2">col4</Column>
+- </Row>
++ <GridContainer gridGap="15px" gridTemplateColumns="repeat(10, 1fr)" columnDivide>
++   <GridItem justifySelf="start" gridColumn="2 / span 3">col1</GridItem>
++   <GridItem justifySelf="center" gridColumn="span 2">col2</GridItem>
++   <GridItem justifySelf="center" gridColumn="span 2">col3</GridItem>
++   <GridItem justifySelf="end" gridColumn="span 2">col4</GridItem>
++ </GridContainer>
+```
+
+This codemod could not convert `gutter` value that is passed down from the parent component, that value must be manually corrected based on the table below:
+| `gutter` | `gridGap` |
+| --- | --- |
+| "extra-small" | "2px" |
+| "small" | "5px" |
+| "medium-small" | "10px" |
+| "medium" | "15px" |
+| "medium-large" | "30px" |
+| "large" | "60px" |
+| "extra-large" | "90px" |
+| "none" | "0" |
+
+The `Row` component `columnDivide` prop functionality could not be replicated in `GridContainer` and replication of that functionality should be addressed manually.
+
+It's likely that props might be assigned in a different manners, therefore this codemod accounts for several prop patterns.
+
+```js
+<Row gutter="medium" columns="5">
+  <Column columns="5" columnSpan="3" columnAlign="left">
+    ...
+  </Column>
+</Row>
+```
+
+```js
+<Row {...{ gutter: "medium", columns: "5" }}>
+  <Column {...{ columns: "5", columnSpan: "3", columnAlign: "left" }}>
+    ...
+  </Column>
+</Row>
+```
+
+```js
+const gutter = "medium";
+const columns = "5";
+const columnSpan = "3";
+const columnAlign = "left";
+
+<Row gutter={gutter} columns={columns}>
+  <Column columns={columns} columnSpan={columnSpan} columnAlign={columnAlign}>
+    ...
+  </Column>
+</Row>;
+```
+
+```js
+const rowProps = {
+  gutter: "medium",
+  columns: "5",
+};
+
+<Row {...rowProps}>
+  <Column columns={columns} columnSpan={columnSpan} columnAlign={columnAlign}>
+    ...
+  </Column>
+</Row>;
+```
+
+```js
+const gutter = "medium";
+const columns = "5";
+const columnSpan = "3";
+const columnAlign = "left";
+
+<Row {...{ gutter, columns }}>
+  <Column {...{ columns, columnSpan, columnAlign }}>...</Column>
+</Row>;
+```
+
+```js
+const foo = "medium";
+const bar = "5";
+const baz = "3";
+const qux = "left";
+
+<Row {...{ gutter: foo, columns: bar }}>
+  <Column {...{ columns: bar, columnSpan: baz, columnAlign: qux }}>...</Column>
+</Row>;
+```
+
+If there is a pattern that you use that is not transformed, please file a feature request.
+
+## Usage
+
+`npx carbon-codemod replace-row-column-with-grid <target>`
+
+### Example
+
+`npx carbon-codemod replace-row-column-with-grid src`

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithGridImport.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithGridImport.input.js
@@ -1,0 +1,19 @@
+import { Row, Column } from "carbon-react/lib/components/row";
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithGridImport = () => (
+  <>
+    <Row gutter="medium" columns="7" columnDivide>
+      <Column columns="foo">col1</Column>
+      <Column columns="7">col2</Column>
+      <Column columns="7">col3</Column>
+    </Row>
+    <GridContainer gridGap="15px" gridTemplateColumns="repeat(7, 1fr)">
+      <GridItem>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  </>
+);
+
+export default WithGridImport;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithGridImport.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithGridImport.output.js
@@ -1,0 +1,18 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithGridImport = () => (
+  <>
+    <GridContainer gridGap="15px" gridTemplateColumns="repeat(7, 1fr)" columnDivide>
+      <GridItem>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+    <GridContainer gridGap="15px" gridTemplateColumns="repeat(7, 1fr)">
+      <GridItem>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  </>
+);
+
+export default WithGridImport;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralPropValues.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralPropValues.input.js
@@ -1,0 +1,12 @@
+import { Row, Column } from "carbon-react/lib/components/row";
+
+const WithLiteralPropValues = () => (
+  <Row gutter="medium" columns="10" columnDivide>
+    <Column columns="10" columnAlign="left" columnSpan="3" columnOffset="1">col1</Column>
+    <Column columns="10" columnAlign="center" columnSpan="2">col2</Column>
+    <Column columns="10" columnAlign="middle" columnSpan="2">col3</Column>
+    <Column columns="10" columnAlign="right" columnSpan="2">col4</Column>
+  </Row>
+);
+
+export default WithLiteralPropValues;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralPropValues.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralPropValues.output.js
@@ -1,0 +1,12 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithLiteralPropValues = () => (
+  <GridContainer gridGap="15px" gridTemplateColumns="repeat(10, 1fr)" columnDivide>
+    <GridItem justifySelf="start" gridColumn="2 / span 3">col1</GridItem>
+    <GridItem justifySelf="center" gridColumn="span 2">col2</GridItem>
+    <GridItem justifySelf="center" gridColumn="span 2">col3</GridItem>
+    <GridItem justifySelf="end" gridColumn="span 2">col4</GridItem>
+  </GridContainer>
+);
+
+export default WithLiteralPropValues;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralValuesInExpression.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralValuesInExpression.input.js
@@ -1,0 +1,14 @@
+import { Row } from "carbon-react/lib/components/row";
+import { Column } from "carbon-react/lib/components/row";
+
+const WithLiteralValuesInExpression = () => (
+  <Row gutter={"medium"} columns={10} columnDivide>
+    <Column columns={10} columnAlign={"left"} columnSpan={3} columnOffset={1}>col1</Column>
+    <Column columns={10} columnAlign={"center"} columnSpan={2}>col2</Column>
+    <Column columns={10} columnAlign={"middle"} columnSpan={2}>col3</Column>
+    <Column columns={10} columnAlign={"right"} columnSpan={2}>col4</Column>
+  </Row>
+);
+
+export default WithLiteralValuesInExpression;
+

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralValuesInExpression.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithLiteralValuesInExpression.output.js
@@ -1,0 +1,12 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithLiteralValuesInExpression = () => (
+  <GridContainer gridGap="15px" gridTemplateColumns="repeat(10, 1fr)" columnDivide>
+    <GridItem justifySelf="start" gridColumn="2 / span 3">col1</GridItem>
+    <GridItem justifySelf="center" gridColumn="span 2">col2</GridItem>
+    <GridItem justifySelf="center" gridColumn="span 2">col3</GridItem>
+    <GridItem justifySelf="end" gridColumn="span 2">col4</GridItem>
+  </GridContainer>
+);
+
+export default WithLiteralValuesInExpression;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsDeclaredInOpeningElement.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsDeclaredInOpeningElement.input.js
@@ -1,0 +1,14 @@
+import { Row } from "carbon-react/lib/components/row";
+import { Column } from "carbon-react/lib/components/row";
+
+const WithPropsDeclaredInOpeningElement = (otherProp) => {
+  return (
+    <Row {...{gutter: "medium", columns: "8"}}>
+      <Column {...{columns: "8", columnAlign: "left", columnSpan:"3", columnOffset:"1"}}>col1</Column>
+      <Column {...{columns: "8", columnAlign: "center", columnSpan:"2" }}>col2</Column>
+      <Column {...{columns: "8", columnAlign: "right", columnSpan:"2" }}>col3</Column>
+    </Row>
+    );
+};
+
+export default WithPropsDeclaredInOpeningElement;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsDeclaredInOpeningElement.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsDeclaredInOpeningElement.output.js
@@ -1,0 +1,22 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithPropsDeclaredInOpeningElement = (otherProp) => {
+  return (
+    <GridContainer {...{gridGap: "15px", gridTemplateColumns: "repeat(8, 1fr)"}}>
+      <GridItem {...{
+        justifySelf: "start",
+        gridColumn:"2 / span 3"
+      }}>col1</GridItem>
+      <GridItem {...{
+        justifySelf: "center",
+        gridColumn:"span 2"
+      }}>col2</GridItem>
+      <GridItem {...{
+        justifySelf: "end",
+        gridColumn:"span 2"
+      }}>col3</GridItem>
+    </GridContainer>
+  );
+};
+
+export default WithPropsDeclaredInOpeningElement;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedAndSpreadFromDeclarationScope.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedAndSpreadFromDeclarationScope.input.js
@@ -1,0 +1,19 @@
+import { Row, Column } from "carbon-react/lib/components/row";
+
+const WithPropsPassedAndSpreadFromDeclarationScope = ({gutterSize, columnsCount}) => {
+  const rowProps = {
+    gutter: gutterSize,
+    columns: columnsCount,
+    columnDivide: true,
+  };
+
+  return (
+    <Row {...rowProps}>
+      <Column columns={rowProps.columns}>col1</Column>
+      <Column columns={rowProps.columns}>col2</Column>
+      <Column columns={rowProps.columns}>col3</Column>
+    </Row>
+  );
+}
+
+export default WithPropsPassedAndSpreadFromDeclarationScope;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedAndSpreadFromDeclarationScope.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedAndSpreadFromDeclarationScope.output.js
@@ -1,0 +1,19 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithPropsPassedAndSpreadFromDeclarationScope = ({gutterSize, columnsCount}) => {
+  const rowProps = {
+    gridGap: gutterSize,
+    gridTemplateColumns: `repeat(${columnsCount}, 1fr)`,
+    columnDivide: true,
+  };
+
+  return (
+    <GridContainer {...rowProps}>
+      <GridItem>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  );
+}
+
+export default WithPropsPassedAndSpreadFromDeclarationScope;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedDown.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedDown.input.js
@@ -1,0 +1,13 @@
+import { Row, Column } from "carbon-react/lib/components/row";
+
+const WithPropsPassedDown = (gutter, columns, otherProp) => {
+  return (
+    <Row {...{gutter, columns}}>
+      <Column {...{columns, otherProp}}>col1</Column>
+      <Column>col2</Column>
+      <Column>col3</Column>
+    </Row>
+    );
+};
+
+export default WithPropsPassedDown;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedDown.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsPassedDown.output.js
@@ -1,0 +1,15 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithPropsPassedDown = (gutter, columns, otherProp) => {
+  return (
+    <GridContainer {...{gridGap: gutter, gridTemplateColumns: `repeat(${columns}, 1fr)`}}>
+      <GridItem {...{
+        otherProp
+      }}>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  );
+};
+
+export default WithPropsPassedDown;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSetInDeclarationScope.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSetInDeclarationScope.input.js
@@ -1,0 +1,27 @@
+
+import { Row, Column } from "carbon-react/lib/components/row";
+
+const WithPropsSetInDeclarationScope = ({ largeGutter, threeColumns }) => {
+  let gutterSize = "medium";
+  let columnsCount = 7;
+
+  gutterSize = "small"
+  
+  if (largeGutter) {
+    gutterSize = "large";
+  }
+
+  if (threeColumns) {
+    columnsCount = 3;
+  }
+
+  return (
+    <Row gutter={gutterSize} columns={columnsCount}>
+      <Column columns={7}>col1</Column>
+      <Column columns={7}>col2</Column>
+      <Column columns={7}>col3</Column>
+    </Row>
+  );
+};
+
+export default WithPropsSetInDeclarationScope;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSetInDeclarationScope.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSetInDeclarationScope.output.js
@@ -1,0 +1,27 @@
+
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithPropsSetInDeclarationScope = ({ largeGutter, threeColumns }) => {
+  let gutterSize = "15px";
+  let columnsCount = 7;
+
+  gutterSize = "5px"
+  
+  if (largeGutter) {
+    gutterSize = "60px";
+  }
+
+  if (threeColumns) {
+    columnsCount = 3;
+  }
+
+  return (
+    <GridContainer gridGap={gutterSize} gridTemplateColumns={`repeat(${columnsCount}, 1fr)`}>
+      <GridItem>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  );
+};
+
+export default WithPropsSetInDeclarationScope;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsShorthandMixed.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsShorthandMixed.input.js
@@ -1,0 +1,14 @@
+import { Row, Column } from "carbon-react/lib/components/row";
+
+const WithPropsShorthandMixed = (columns, otherProp) => {
+  const gutter = "medium";
+  return (
+    <Row {...{gutter, columns}}>
+      <Column {...{columns, otherProp}}>col1</Column>
+      <Column>col2</Column>
+      <Column>col3</Column>
+    </Row>
+    );
+};
+
+export default WithPropsShorthandMixed;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsShorthandMixed.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsShorthandMixed.output.js
@@ -1,0 +1,16 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithPropsShorthandMixed = (columns, otherProp) => {
+  const gutter = "15px";
+  return (
+    <GridContainer {...{gridGap: gutter, gridTemplateColumns: `repeat(${columns}, 1fr)`}}>
+      <GridItem {...{
+        otherProp
+      }}>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  );
+};
+
+export default WithPropsShorthandMixed;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSpreadFromDeclarationScope.input.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSpreadFromDeclarationScope.input.js
@@ -1,0 +1,19 @@
+import { Row, Column } from "carbon-react/lib/components/row";
+
+const WithPropsSpreadFromDeclarationScope = () => {
+  const rowProps = {
+    gutter: "medium",
+    columns: 5,
+    columnDivide: true,
+  };
+
+  return (
+    <Row {...rowProps}>
+      <Column columns={rowProps.columns}>col1</Column>
+      <Column columns={rowProps.columns}>col2</Column>
+      <Column columns={rowProps.columns}>col3</Column>
+    </Row>
+  );
+}
+
+export default WithPropsSpreadFromDeclarationScope;

--- a/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSpreadFromDeclarationScope.output.js
+++ b/transforms/replace-row-column-with-grid/__testfixtures__/WithPropsSpreadFromDeclarationScope.output.js
@@ -1,0 +1,19 @@
+import { GridContainer, GridItem } from "carbon-react/lib/components/grid";
+
+const WithPropsSpreadFromDeclarationScope = () => {
+  const rowProps = {
+    gridGap: "15px",
+    gridTemplateColumns: "repeat(5, 1fr)",
+    columnDivide: true,
+  };
+
+  return (
+    <GridContainer {...rowProps}>
+      <GridItem>col1</GridItem>
+      <GridItem>col2</GridItem>
+      <GridItem>col3</GridItem>
+    </GridContainer>
+  );
+}
+
+export default WithPropsSpreadFromDeclarationScope;

--- a/transforms/replace-row-column-with-grid/__tests__/replace-row-column-with-grid.js
+++ b/transforms/replace-row-column-with-grid/__tests__/replace-row-column-with-grid.js
@@ -1,0 +1,17 @@
+import defineTest from "../../../defineTest";
+
+const testFilePrefixes = [
+  "WithGridImport",
+  "WithLiteralPropValues",
+  "WithLiteralValuesInExpression",
+  "WithPropsDeclaredInOpeningElement",
+  "WithPropsPassedAndSpreadFromDeclarationScope",
+  "WithPropsPassedDown",
+  "WithPropsSetInDeclarationScope",
+  "WithPropsShorthandMixed",
+  "WithPropsSpreadFromDeclarationScope",
+];
+
+testFilePrefixes.forEach((testFilePrefix) => {
+  defineTest(__dirname, "replace-row-column-with-grid", null, testFilePrefix);
+});

--- a/transforms/replace-row-column-with-grid/replace-column-align-with-justify-self.js
+++ b/transforms/replace-row-column-with-grid/replace-column-align-with-justify-self.js
@@ -1,0 +1,88 @@
+import { getSpreadObjectProperty, isLiteral, replaceKey } from "./utils";
+
+const names = {
+  columnAlignProp: "columnAlign",
+  justifySelfProp: "justifySelf",
+};
+
+export function replaceColumnAlignWithJustifySelf(j, columnNode) {
+  const spreadAttributes = j(columnNode).find(j.JSXSpreadAttribute);
+
+  if (spreadAttributes.size()) {
+    spreadAttributes.forEach((spreadObject) => {
+      const columnAlignProperty = getSpreadObjectProperty(j, spreadObject, names.columnAlignProp);
+
+      if (!columnAlignProperty) {
+        return;
+      }
+
+      const typeOfSpreadAttributeObject = spreadObject.get(
+        "argument",
+        "type"
+      ).value;
+
+      if (typeOfSpreadAttributeObject === "ObjectExpression") {
+        if (columnAlignProperty.length) {
+          const columnAlignValue = columnAlignProperty.get(
+            "value",
+            "value"
+          ).value;
+
+          replaceKey(j, columnAlignProperty, names.justifySelfProp);
+          columnAlignProperty
+            .get("value")
+            .replace(
+              j.literal(convertColumnAlignToJustifySelf(columnAlignValue))
+            );
+        }
+      }
+    });
+  }
+
+  const columnAlignAttr = j(columnNode).findJSXAttribute(names.columnAlignProp);
+
+  if (columnAlignAttr.length) {
+    const columnAlignValue = columnAlignAttr.get("value", "value").value;
+    const columnAlignValueType = columnAlignAttr.get("value", "type").value;
+
+    columnAlignAttr.get("name").replace(names.justifySelfProp);
+
+    if (isLiteral(columnAlignValueType)) {
+      columnAlignAttr
+        .get("value")
+        .replace(j.literal(convertColumnAlignToJustifySelf(columnAlignValue)));
+    } else {
+      const expressionType = columnAlignAttr.get(
+        "value",
+        "expression",
+        "type"
+      ).value;
+
+      if (isLiteral(expressionType)) {
+        const columnAlignExpressionLiteralValue = columnAlignAttr.get(
+          "value",
+          "expression",
+          "value"
+        ).value;
+
+        columnAlignAttr.get("value").replace(
+          j.literal(convertColumnAlignToJustifySelf(columnAlignExpressionLiteralValue))
+        );
+      }
+    }
+  }
+}
+
+function convertColumnAlignToJustifySelf(columnAlign) {
+  switch (columnAlign) {
+    case "left":
+      return "start";
+    case "right":
+      return "end";
+    case "center":
+    case "middle":
+      return "center";
+    default:
+      return undefined;
+  }
+}

--- a/transforms/replace-row-column-with-grid/replace-column-span-with-grid-column.js
+++ b/transforms/replace-row-column-with-grid/replace-column-span-with-grid-column.js
@@ -1,0 +1,106 @@
+import { getSpreadObjectProperty, isLiteral, replaceKey } from "./utils";
+
+const names = {
+  columnSpanProp: "columnSpan",
+  columnOffsetProp: "columnOffset",
+  gridColumnProp: "gridColumn",
+};
+
+export function replaceColumnSpanWithGridColumn(j, columnNode) {
+  const columnSpanAttr = j(columnNode).findJSXAttribute(names.columnSpanProp);
+  const columnOffsetAttr = j(columnNode).findJSXAttribute(
+    names.columnOffsetProp
+  );
+  const spreadAttributes = j(columnNode).find(j.JSXSpreadAttribute);
+  let offset;
+
+  if (columnOffsetAttr.length) {
+    offset = getColumnOffsetLiteralValue(columnOffsetAttr);
+    columnOffsetAttr.remove();
+  }
+
+  if (columnSpanAttr.length) {
+    const offsetPart = offset ? `${offset} / ` : "";
+    const columnSpanValue = columnSpanAttr.get("value", "value").value;
+    const columnSpanValueType = columnSpanAttr.get("value", "type").value;
+
+    columnSpanAttr.get("name").replace(names.gridColumnProp);
+
+    if (isLiteral(columnSpanValueType)) {
+      columnSpanAttr
+        .get("value")
+        .replace(
+          j.literal(
+            `${offsetPart}span ${columnSpanValue}`
+          )
+        );
+    } else if (columnSpanValueType === "JSXExpressionContainer") {
+      const columnSpanExpression = columnSpanAttr.get("value", "expression");
+
+      if (isLiteral(columnSpanExpression.get("type").value)) {
+        columnSpanAttr
+          .get("value")
+          .replace(
+            j.literal(
+              `${offsetPart}span ${columnSpanExpression.get("value").value}`
+            )
+          );
+      }
+    }
+  }
+
+  if (spreadAttributes.size()) {
+    spreadAttributes.forEach((spreadObject) => {
+      convertSpreadObjectValues(j, spreadObject);
+    });
+  }
+}
+
+function convertSpreadObjectValues(j, spreadObject) {
+  const columnSpanProperty = getSpreadObjectProperty(j, spreadObject, names.columnSpanProp);
+  const columnOffsetAttr = getSpreadObjectProperty(j, spreadObject, names.columnOffsetProp);
+
+  const typeOfSpreadAttributeObject = spreadObject.get(
+    "argument",
+    "type"
+  ).value;
+
+  if (typeOfSpreadAttributeObject === "ObjectExpression") {
+    let offset;
+
+    if (columnOffsetAttr) {
+      offset = getColumnOffsetLiteralValue(columnOffsetAttr);
+      columnOffsetAttr.remove();
+    }
+
+    const offsetPart = offset ? `${offset} / ` : "";
+
+    if (columnSpanProperty) {
+      const columnSpanPropertyType = columnSpanProperty.get("value", "type").value;
+
+      if (isLiteral(columnSpanPropertyType)) {
+        const columnSpanValue = columnSpanProperty.get("value", "value").value;
+
+        replaceKey(j, columnSpanProperty, names.gridColumnProp);
+        columnSpanProperty
+          .get("value")
+          .replace(j.literal(`${offsetPart}span ${columnSpanValue}`));
+      }
+    }
+  }
+}
+
+function getColumnOffsetLiteralValue(columnOffsetAttr) {
+  const columnOffsetValue = columnOffsetAttr.get("value", "value").value;
+  const columnOffsetValueType = columnOffsetAttr.get("value", "type").value;
+
+  if (isLiteral(columnOffsetValueType)) {
+    return Number(columnOffsetValue) + 1;
+  } else if (columnOffsetValueType === "JSXExpressionContainer") {
+    const columnOffsetExpression = columnOffsetAttr.get("value", "expression");
+
+    if (isLiteral(columnOffsetExpression.get("type").value)) {
+      return Number(columnOffsetExpression.get("value").value) + 1;
+    }
+  }
+}

--- a/transforms/replace-row-column-with-grid/replace-columns-with-grid-template-columns.js
+++ b/transforms/replace-row-column-with-grid/replace-columns-with-grid-template-columns.js
@@ -1,0 +1,194 @@
+import {
+  getPropertyFromDeclarationScope,
+  getSpreadObjectProperty,
+  isLiteral,
+  replaceKey,
+  replaceLiteralExpressionAssignments,
+  replaceValue,
+} from "./utils";
+
+const names = {
+  columnsProp: "columns",
+  gridTemplateColumnsProp: "gridTemplateColumns",
+};
+
+export function replaceColumnsWithGridTemplateColumns(j, rowNode) {
+  const spreadAttributeObjects = j(rowNode.node.openingElement).find(
+    j.JSXSpreadAttribute
+  );
+
+  if (spreadAttributeObjects.size()) {
+    // prop spread
+    spreadAttributeObjects.forEach((spreadObject) => {
+      const typeOfSpreadAttributeObject = spreadObject.get(
+        "argument",
+        "type"
+      ).value;
+
+      if (typeOfSpreadAttributeObject === "Identifier") {
+        // props spread from an object in declaration scope e.g.: <Component {...props}>
+        const columnsInDeclarationScope = getPropertyFromDeclarationScope(
+          j,
+          rowNode,
+          spreadObject.value.argument.name,
+          names.columnsProp
+        );
+
+        if (columnsInDeclarationScope) {
+          const columnsInDeclarationScopeValueType =
+            columnsInDeclarationScope.get("value", "type").value;
+
+          if (isLiteral(columnsInDeclarationScopeValueType)) {
+            // replace literal value in declaration scope e.g.: columns: 7 -> gridTemplateColumns: "repeat(7, 1fr)"
+            replaceValue(
+              j,
+              columnsInDeclarationScope,
+              names.columnsProp,
+              getGridTemplateColumns
+            );
+            replaceKey(
+              j,
+              columnsInDeclarationScope,
+              names.gridTemplateColumnsProp
+            );
+          } else if (columnsInDeclarationScopeValueType === "Identifier") {
+            columnsInDeclarationScope
+              .get("value")
+              .replace(
+                getGridTemplateQuasis(
+                  j,
+                  columnsInDeclarationScope.get("value").value
+                )
+              );
+            replaceKey(
+              j,
+              columnsInDeclarationScope,
+              names.gridTemplateColumnsProp
+            );
+          }
+        }
+      } else if (typeOfSpreadAttributeObject === "ObjectExpression") {
+        // props spread in the opening element e.g.: <Row {...{columns: 7}}>
+        const columnsProperty = getSpreadObjectProperty(j, spreadObject, names.columnsProp);
+
+        if (!columnsProperty) {
+          return;
+        }
+
+        const coumnsPropertyValueType = columnsProperty.get(
+          "value",
+          "type"
+        ).value;
+
+        replaceKey(j, columnsProperty.get(), names.gridTemplateColumnsProp);
+
+        if (isLiteral(coumnsPropertyValueType)) {
+          columnsProperty
+            .get("value")
+            .replace(
+              j.literal(
+                getGridTemplateColumns(
+                  columnsProperty.get("value", "value").value
+                )
+              )
+            );
+        } else if (coumnsPropertyValueType === "Identifier") {
+          if (columnsProperty.get("shorthand").value) {
+            replaceShorthandProp(j, columnsProperty, names.gridTemplateColumnsProp);
+          } else {
+            columnsProperty
+              .get("value")
+              .replace(
+                getGridTemplateQuasis(j, columnsProperty.get("value").value)
+              );
+          }
+        }
+      }
+    });
+  }
+
+  const columnsAttr = j(rowNode).findJSXAttribute(names.columnsProp);
+
+  if (columnsAttr.length) {
+    const columnsValue = columnsAttr.get("value");
+
+    columnsAttr.get("name").replace(names.gridTemplateColumnsProp);
+
+    if (isLiteral(columnsValue.value.type)) {
+      // replace literal value in a JSX node e.g.: <Row columns="7">
+      columnsValue.replace(
+        j.literal(getGridTemplateColumns(columnsValue.value.value))
+      );
+    } else if (columnsValue.value.type === "JSXExpressionContainer") {
+      const expressionType = columnsAttr.get(
+        "value",
+        "expression",
+        "type"
+      ).value;
+
+      if (isLiteral(expressionType)) {
+        columnsValue.replace(
+          j.literal(getGridTemplateColumns(columnsValue.value.expression.value))
+        );
+      } else {
+        const expression = columnsAttr.get("value", "expression");
+        const templateLiteral = getGridTemplateQuasis(j, expression.value);
+
+        expression.replace(templateLiteral);
+      }
+    } else {
+      // replace literal values in declaration scope
+      const expressionName = columnsValue.value.expression.name;
+
+      replaceLiteralExpressionAssignments(
+        j,
+        rowNode,
+        expressionName,
+        getGridTemplateColumns
+      );
+    }
+  }
+}
+
+function getGridTemplateColumns(columns) {
+  return `repeat(${columns}, 1fr)`;
+}
+
+function getGridTemplateQuasis(j, propValue) {
+  const gridTemplateQuasis = j.templateLiteral(
+    [
+      j.templateElement({ cooked: "repeat(", raw: "repeat(" }, false),
+      j.templateElement({ cooked: ", 1fr)", raw: ", 1fr)" }, true),
+    ],
+    [propValue]
+  );
+
+  return gridTemplateQuasis;
+}
+
+function replaceShorthandProp(j, shorthandProp, newValue) {
+  const shorthandPropType = shorthandProp.get("type").value;
+
+  if (shorthandPropType === "Property") {
+    shorthandProp
+      .get()
+      .replace(
+        j.property(
+          "init",
+          j.identifier(newValue),
+          getGridTemplateQuasis(j, shorthandProp.get("value").value)
+        )
+      );
+  }
+
+  if (shorthandPropType === "ObjectProperty") {
+    shorthandProp
+      .get()
+      .replace(
+        j.objectProperty(
+          j.identifier(newValue),
+          getGridTemplateQuasis(j, shorthandProp.get("value").value)
+        )
+      );
+  }
+}

--- a/transforms/replace-row-column-with-grid/replace-gutter-with-grid-gap.js
+++ b/transforms/replace-row-column-with-grid/replace-gutter-with-grid-gap.js
@@ -1,0 +1,148 @@
+import {
+  getPropertyFromDeclarationScope,
+  getSpreadObjectProperty,
+  isLiteral,
+  replaceKey,
+  replaceLiteralExpressionAssignments,
+  replaceValue,
+} from "./utils";
+
+const names = {
+  gutterProp: "gutter",
+  gridGapProp: "gridGap",
+};
+
+export function replaceGutterWithGridGap(j, rowNode) {
+  const spreadAttributeObjects = j(rowNode.node.openingElement).find(
+    j.JSXSpreadAttribute
+  );
+
+  // gutter as a simple JSX Attribute, e.g.: gutter="medium"
+  const gutterAttr = j(rowNode).findJSXAttribute(names.gutterProp);
+
+  if (gutterAttr.length) {
+    const gutterValue = gutterAttr.get("value");
+
+    gutterAttr.get("name").replace(names.gridGapProp);
+
+    if (isLiteral(gutterValue.value.type)) {
+      // replace literal value in JSX node
+      gutterValue.replace(
+        j.literal(convertGutterToGridGap(gutterValue.value.value))
+      );
+    } else {
+      // replace literal values in declaration scope
+      const expressionType = gutterAttr.get(
+        "value",
+        "expression",
+        "type"
+      ).value;
+      const expressionName = gutterValue.value.expression.name;
+
+      if (isLiteral(expressionType)) {
+        const gutterExpressionLiteralValue = gutterValue.get(
+          "expression",
+          "value"
+        ).value;
+
+        gutterValue.replace(
+          j.literal(convertGutterToGridGap(gutterExpressionLiteralValue))
+        );
+      } else if (expressionType === "Identifier") {
+        replaceLiteralExpressionAssignments(
+          j,
+          rowNode,
+          expressionName,
+          convertGutterToGridGap
+        );
+      }
+    }
+  }
+
+  if (spreadAttributeObjects.size()) {
+    // prop spread
+    spreadAttributeObjects.forEach((spreadObject) => {
+      convertSpreadObjectValues(j, spreadObject, rowNode);
+    });
+  }
+}
+
+function convertSpreadObjectValues(j, spreadObject, rowNode) {
+  const typeOfSpreadAttributeObject = spreadObject.get(
+    "argument",
+    "type"
+  ).value;
+
+  if (typeOfSpreadAttributeObject === "Identifier") {
+    // props spread from an object in declaration scope e.g.: <Row {...props}>
+    const gutterInDeclarationScope = getPropertyFromDeclarationScope(
+      j,
+      rowNode,
+      spreadObject.value.argument.name,
+      names.gutterProp
+    );
+
+    if (gutterInDeclarationScope) {
+      const gutterValueType = gutterInDeclarationScope.get(
+        "value",
+        "type"
+      ).value;
+
+      if (isLiteral(gutterValueType)) {
+        // replace literal value in declaration scope e.g.: gutter: "medium" -> gridGap: "15px"
+        replaceValue(
+          j,
+          gutterInDeclarationScope,
+          names.gutterProp,
+          convertGutterToGridGap
+        );
+        replaceKey(j, gutterInDeclarationScope, names.gridGapProp);
+      } else if (gutterValueType === "Identifier") {
+        replaceKey(j, gutterInDeclarationScope, names.gridGapProp);
+      }
+    }
+  } else if (typeOfSpreadAttributeObject === "ObjectExpression") {
+    // props spread in the opening element e.g.: <Row {...{gutter: "medium"}}>
+    const gutterProperty = getSpreadObjectProperty(j, spreadObject, names.gutterProp);
+
+    if (!gutterProperty) {
+      return;
+    }
+
+    const gutterPropName = gutterProperty.get("value", "name").value;
+
+    replaceValue(j, gutterProperty.get(), gutterPropName, convertGutterToGridGap);
+    replaceKey(j, gutterProperty.get(), names.gridGapProp);
+
+    if (gutterProperty.get("value", "type").value === "Identifier") {
+      replaceLiteralExpressionAssignments(
+        j,
+        rowNode,
+        gutterPropName,
+        convertGutterToGridGap
+      );
+    }
+  }
+}
+
+function convertGutterToGridGap(gutter) {
+  switch (gutter) {
+    case "extra-small":
+      return "2px";
+    case "small":
+      return "5px";
+    case "medium-small":
+      return "10px";
+    case "medium":
+      return "15px";
+    case "medium-large":
+      return "30px";
+    case "large":
+      return "60px";
+    case "extra-large":
+      return "90px";
+    case "none":
+    default:
+      return 0;
+  }
+}

--- a/transforms/replace-row-column-with-grid/replace-row-column-with-grid.js
+++ b/transforms/replace-row-column-with-grid/replace-row-column-with-grid.js
@@ -1,0 +1,186 @@
+import registerMethods from "../registerMethods";
+import { replaceColumnAlignWithJustifySelf } from "./replace-column-align-with-justify-self";
+import { replaceColumnSpanWithGridColumn } from "./replace-column-span-with-grid-column";
+import { replaceColumnsWithGridTemplateColumns } from "./replace-columns-with-grid-template-columns";
+import { replaceGutterWithGridGap } from "./replace-gutter-with-grid-gap";
+import { getSpreadObjectProperty } from "./utils";
+
+const rowImportString = "carbon-react/lib/components/row";
+const gridImportString = "carbon-react/lib/components/grid";
+
+const names = {
+  columnsProp: "columns",
+  rowComponent: "Row",
+  columnComponent: "Column",
+  gridContainer: "GridContainer",
+  gridItem: "GridItem",
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const rowImportDeclaration = root.find(j.ImportDeclaration, {
+    source: {
+      value: rowImportString,
+    },
+  });
+
+  if (!rowImportDeclaration.size()) {
+    return;
+  }
+  const hasRowImport =
+    root
+      .find(j.ImportSpecifier, {
+        local: {
+          name: "Row",
+        },
+      })
+      .size() > 0;
+
+  const hasColumnImport =
+    root
+      .find(j.ImportSpecifier, {
+        local: {
+          name: "Column",
+        },
+      })
+      .size() > 0;
+
+  registerMethods(j);
+  replaceImports();
+  replaceRowWithGridContainer();
+  replaceColumnWithGridItem();
+
+  // replace all non JSX instances, e.g.: component.toBe(Row) -> component.toBe(GridContainer)
+  if (hasRowImport) {
+    root
+      .find(j.Identifier, {
+        name: names.rowComponent,
+      })
+      .replaceWith(j.identifier(names.gridContainer));
+  }
+
+  if (hasColumnImport) {
+    root
+      .find(j.Identifier, {
+        name: names.columnComponent,
+      })
+      .replaceWith(j.identifier(names.gridItem));
+  }
+
+  function replaceImports() {
+    let gridImportDeclaration = root.find(j.ImportDeclaration, {
+      source: {
+        value: gridImportString,
+      },
+    });
+
+    const hasGridContainerImport =
+      root
+        .find(j.ImportSpecifier, {
+          local: {
+            name: "GridContainer",
+          },
+        })
+        .size() > 0;
+
+    const hasGridItemImport =
+      root
+        .find(j.ImportSpecifier, {
+          local: {
+            name: "GridItem",
+          },
+        })
+        .size() > 0;
+
+    if (gridImportDeclaration.size()) {
+      if (hasRowImport && !hasGridContainerImport) {
+        gridImportDeclaration
+          .get("specifiers")
+          .value.push(j.importSpecifier(j.identifier(names.gridContainer)));
+      } else if (hasColumnImport && !hasGridItemImport) {
+        gridImportDeclaration
+          .get("specifiers")
+          .value.push(j.importSpecifier(j.identifier(names.gridItem)));
+      }
+
+      rowImportDeclaration.remove();
+    } else {
+      gridImportDeclaration = j.importDeclaration(
+        [],
+        j.stringLiteral(gridImportString)
+      );
+
+      if (hasRowImport) {
+        gridImportDeclaration.specifiers.push(
+          j.importSpecifier(j.identifier(names.gridContainer))
+        );
+      }
+
+      if (hasColumnImport) {
+        gridImportDeclaration.specifiers.push(
+          j.importSpecifier(j.identifier(names.gridItem))
+        );
+      }
+
+      rowImportDeclaration.replaceWith(gridImportDeclaration);
+
+      if (rowImportDeclaration.size() > 1) {
+        rowImportDeclaration
+          .filter((importDeclaration, index) => {
+            return index > 0;
+          })
+          .remove();
+      }
+    }
+  }
+
+  function replaceRowWithGridContainer() {
+    let rowNodes = root.findJSXElements(names.rowComponent);
+
+    rowNodes.forEach((rowNode) => {
+      replaceGutterWithGridGap(j, rowNode);
+      replaceColumnsWithGridTemplateColumns(j, rowNode);
+      replaceJSXElementName(rowNode, names.gridContainer);
+    });
+  }
+
+  function replaceColumnWithGridItem() {
+    let columnNodes = root.findJSXElements(names.columnComponent);
+
+    columnNodes.forEach((columnNode) => {
+      replaceColumnSpanWithGridColumn(j, columnNode);
+      replaceColumnAlignWithJustifySelf(j, columnNode);
+
+      const spreadAttributes = j(columnNode).find(j.JSXSpreadAttribute);
+
+      if (spreadAttributes.size()) {
+        spreadAttributes.forEach((spreadObject) => {
+          const columnsProperty = getSpreadObjectProperty(j, spreadObject, names.columnsProp);
+
+          if (columnsProperty) {
+          	columnsProperty.remove();
+          }
+        });
+      }
+
+      const columnsAttr = j(columnNode).findJSXAttribute(names.columnsProp);
+
+      if (columnsAttr.length) {
+        columnsAttr.remove();
+      }
+
+      replaceJSXElementName(columnNode, names.gridItem);
+    });
+  }
+
+  function replaceJSXElementName(element, newName) {
+    element.get("openingElement", "name").replace(j.jsxIdentifier(newName));
+
+    if (element.get("closingElement").value) {
+      element.get("closingElement", "name").replace(j.jsxIdentifier(newName));
+    }
+  }
+
+  return root.toSource();
+}

--- a/transforms/replace-row-column-with-grid/utils.js
+++ b/transforms/replace-row-column-with-grid/utils.js
@@ -1,0 +1,139 @@
+export function getPropertyFromDeclarationScope(j, element, attributeName, propName) {
+  const propObject = j(element).findVariableDeclaration(attributeName, {
+    type: "ObjectExpression",
+  });
+
+  const esprimaProperty = propObject
+    .find(j.Property, {
+      kind: "init",
+      key: { name: propName },
+    });
+
+  const babelParserProperty = propObject
+    .find(j.ObjectProperty, {
+      key: { name: propName },
+    });
+
+  if (esprimaProperty.length) {
+    return esprimaProperty;
+  } else if (babelParserProperty.length) {
+    return babelParserProperty;
+  }
+
+  return undefined;
+}
+
+export function isLiteral(type) {
+  return type === "Literal" || type === "StringLiteral" || type === "NumericLiteral";
+}
+
+export function replaceLiteralExpressionAssignments(
+  j,
+  node,
+  propName,
+  replacementMethod
+) {
+  const variableDeclaration = getVariableDeclarationWithLiteralValue(j, node, propName);
+
+  if (variableDeclaration) {
+    variableDeclaration
+      .get("init", "value")
+      .replace(
+        replacementMethod(variableDeclaration.get("init", "value").value)
+      );
+
+    const literalExpressionAssignments = getLiteralExpressionAssignments(
+      j,
+      node,
+      propName
+    );
+
+    if (!literalExpressionAssignments) {
+      return;
+    }
+
+    literalExpressionAssignments.forEach((nodePath) => {
+      nodePath
+        .get("right")
+        .replace(j.literal(replacementMethod(nodePath.value.right.value)));
+    });
+  }
+}
+
+export function replaceKey(j, element, newKey) {
+  element.get("key").replace(j.identifier(newKey));
+}
+
+export function replaceValue(j, property, newIdentifier, convertMethod) {
+  const propValue = property.get("value");
+  const valueType = propValue.get("type").value;
+
+  if (isLiteral(valueType)) {
+    const literalValue = propValue.get("value").value;
+    propValue.replace(j.literal(convertMethod(literalValue)));
+  } else if (valueType === "Identifier") {
+    if (property.get("shorthand").value) {
+      property.replace(
+        j.property(
+          "init",
+          j.literal(property.get("key", "name").value),
+          j.identifier(newIdentifier)
+        )
+      );
+    } else {
+      propValue.replace(j.identifier(newIdentifier));
+    }
+  }
+}
+
+export function getSpreadObjectProperty(j, spreadObject, propertyName) {
+  const esprimaProperty = j(spreadObject)
+    .find(j.Property, {
+      kind: "init",
+      key: { name: propertyName },
+    });
+
+  const babelParserProperty = j(spreadObject)
+    .find(j.ObjectProperty, {
+      key: { name: propertyName },
+    });
+
+  if (esprimaProperty.length) {
+    return esprimaProperty;
+  } else if (babelParserProperty.length) {
+    return babelParserProperty;
+  }
+
+  return undefined;
+}
+
+function getLiteralExpressionAssignments(j, element, attributeName) {
+  const declarationScope = j(element).findDeclarationScope(attributeName);
+
+  const assignmnetExpressions = ["Literal", "StringLiteral", "NumericLiteral"].reduce((acc, type) => {
+    const expressions = j(declarationScope.path).find(j.AssignmentExpression, {
+      left: {
+        name: attributeName,
+      },
+      right: {
+        type,
+      },
+    });
+
+    return expressions.length ? expressions : acc;
+  }, undefined);
+
+  return assignmnetExpressions;
+}
+
+function getVariableDeclarationWithLiteralValue(j, node, propName) {
+  const withLiteralValue = ["Literal", "StringLiteral", "NumericLiteral"].reduce((acc, type) => {
+    const variableDeclaration = j(node).findVariableDeclaration(propName, {
+      type,
+    });
+
+    return variableDeclaration.length ? variableDeclaration : acc;
+  }, undefined);
+
+  return withLiteralValue;
+}


### PR DESCRIPTION
### Proposed behaviour

The `Row` and `Column` components have been deprecated in favour of `GridContainer` and `GridItem` components respectively. This codemod converts all `Row` and `Column` instances to `GridContainer` and `GridItem`

The codemod will also replace `Row` props with their `GridContainer` equivalents:

- `gutter` will be changed to `gridGap`
- `columns` will be changed to `gridTemplateColumns`

and `Column` props with their `GridItem` equivalents:

- `columnSpan` will be changed to `gridColumn`, only literal values will be changed, e.g.:`columnSpan={3}`, `columnSpan="3"`, `{...{ columnSpan: 3 }}`, `{...{ columnSpan: "3" }}`
- `columnAlign` will be changed to `justifySelf` only literal values will be changed, e.g.: `columnAlign="left"`, `{...{ columnAlign: "left" }}`

```diff
- import { Row, Column } from "carbon-react/lib/components/row";
+ import { GridContainer, GridItem } from "carbon-react/lib/components/grid";

- <Row gutter="medium" columns="10">
-   <Column columns="10" columnAlign="left" columnSpan="3" columnOffset="1">col1</Column>
-   <Column columns="10" columnAlign="center" columnSpan="2">col1</Column>
-   <Column columns="10" columnAlign="middle" columnSpan="2">col3</Column>
-   <Column columns="10" columnAlign="right" columnSpan="2">col3</Column>
- </Row>
+ <GridContainer gridGap="15px" gridTemplateColumns="repeat(10, 1fr)" columnDivider>
+   <GridItem justifySelf="start" gridColumn="2 / span 3">col1</GridItem>
+   <GridItem justifySelf="center" gridColumn="span 2">col1</GridItem>
+   <GridItem justifySelf="center" gridColumn="span 2">col3</GridItem>
+   <GridItem justifySelf="end" gridColumn="span 2">col3</GridItem>
+ </GridContainer>
```

### Current behaviour

NO codemod exists

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

### Additional context

FE-3569

### Testing instructions

Follow instructions in README to run `npx carbon-codemod replace-row-column-with-grid <target>`