### PR TITLE
fix(parser): revert parser to default and add typescript option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ Note that `<target>` is worked out relative to the current working directory.
 Make sure that the codemod is not being run in a folder containing a `package.json` file,
 as it may fail reporting missing dependencies.
 
+For TypeScript codebase conversion use the `--typescript` option:
+
+```
+npx carbon-codemod <name-of-codemod> <target> --typescript
+```
+
+List of codemods with TypeScript support:
+
+- [`message-remove-classic-theme`](./transforms/message-remove-classic-theme)
+- [`move-experimental-components`](./transforms/move-experimental-components)
+- [`rename-prop`](./transforms/rename-prop)
+- [`remove-prop`](./transforms/remove-prop)
+- [`replace-row-column-with-grid`](./transforms/replace-row-column-with-grid)
+
+
 ## Development
 
 `carbon-codemod` is a wrapper around [`jscodeshift`](https://github.com/facebook/jscodeshift).
@@ -56,7 +71,7 @@ It's also possible to debug the tests
 
 You can use [astexplorer.net](https://astexplorer.net/) to help understand the existing structure of files. You should use the following settings:
 
-- parser: `esprima`
+- parser: `esprima` for js or `@babel/parser` for TypeScript
 - transform: `jscodeshift`
 
 ### Transformation Status
@@ -75,6 +90,7 @@ The return value of the function determines the status of the transformation:
 - `npm test`
 - It's important to test that each codemod is idempotent.
 - Use `defineTest` to write new tests, this will create a fixture test and an idempotent test.
+- A codemod should convert both javascript and TypeScript projects.
 
 ### Releasing
 

--- a/bin/__tests__/carbon-codemod.js
+++ b/bin/__tests__/carbon-codemod.js
@@ -77,6 +77,23 @@ describe("run", () => {
     expect(execaSync.mock.calls[0][1]).toContain("--dry");
   });
 
+  describe("when the --typescript flag is set", () => {
+    it("sets the parser as tsx and supports ts extensions", () => {
+      process.argv = [
+        "/Users/guest/.nvm/versions/node/v10.16.3/bin/node",
+        "/Users/guest/.nvm/versions/node/v10.16.3/bin/carbon-codemod",
+        "button-destructive",
+        "src",
+        "--typescript",
+      ];
+
+      new Cli().run();
+
+      expect(console.log.mock.calls[0][0]).toContain("--parser=tsx");
+      expect(console.log.mock.calls[0][0]).toContain("--extensions=tsx,ts,jsx,js");
+    });
+  });
+
   describe("git", () => {
     beforeEach(() => {
       process.argv = [
@@ -165,8 +182,7 @@ describe("run", () => {
       const args = [
         "--verbose=2",
         "--ignore-pattern=**/node_modules/**",
-        "--parser=tsx",
-        "--extensions=tsx,ts,jsx,js",
+        "--extensions=jsx,js",
         "--transform",
         path.join(
           Cli.__transformsDir,
@@ -192,8 +208,7 @@ describe("run", () => {
       const args = [
         "--verbose=2",
         "--ignore-pattern=**/node_modules/**",
-        "--parser=tsx",
-        "--extensions=tsx,ts,jsx,js",
+        "--extensions=jsx,js",
         "--transform",
         path.join(
           Cli.__transformsDir,
@@ -219,8 +234,7 @@ describe("run", () => {
       const args = [
         "--verbose=2",
         "--ignore-pattern=**/node_modules/**",
-        "--parser=tsx",
-        "--extensions=tsx,ts,jsx,js",
+        "--extensions=jsx,js",
         "--transform",
         path.join(
           Cli.__transformsDir,
@@ -249,8 +263,7 @@ describe("run", () => {
       const args = [
         "--verbose=2",
         "--ignore-pattern=**/node_modules/**",
-        "--parser=tsx",
-        "--extensions=tsx,ts,jsx,js",
+        "--extensions=jsx,js",
         "--transform",
         path.join(Cli.__transformsDir, "rename-prop", "rename-prop.js"),
         path.join(process.cwd(), "src"),
@@ -277,8 +290,7 @@ describe("run", () => {
       const args = [
         "--verbose=2",
         "--ignore-pattern=**/node_modules/**",
-        "--parser=tsx",
-        "--extensions=tsx,ts,jsx,js",
+        "--extensions=jsx,js",
         "--transform",
         path.join(Cli.__transformsDir, "remove-prop", "remove-prop.js"),
         path.join(process.cwd(), "src"),

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -39,7 +39,7 @@ const transformsDir = path.resolve(__dirname, "../", "transforms");
 
 const runTransform = (target, command, program, options = {}) => {
   try {
-    const { force, dry } = program.opts();
+    const { force, dry, typescript } = program.opts();
     const name = command.name();
 
     if (!dry) {
@@ -51,9 +51,13 @@ const runTransform = (target, command, program, options = {}) => {
       args.push("--dry");
     }
 
-    args.push("--parser=tsx");
+    if (typescript) {
+      args.push("--parser=tsx");
+      args.push("--extensions=tsx,ts,jsx,js");
+    } else {
+      args.push("--extensions=jsx,js");
+    }
 
-    args.push("--extensions=tsx,ts,jsx,js");
 
     args.push("--transform", path.join(transformsDir, name, `${name}.js`));
 
@@ -88,16 +92,20 @@ const runTransform = (target, command, program, options = {}) => {
 
 function Cli() {
   const program = new commander.Command();
+
+
   program
     .version(packageJSON.version)
     .option("--force", "skip safety checks")
-    .option("--dry", "dry run (no changes are made to files)");
+    .option("--dry", "dry run (no changes are made to files)")
+    .option("-ts, --typescript", "convert TypeScript code");
 
   program
     .command("button-destructive <target>")
     .description(
       "Convert destructive buttons to primary buttons with a destructive prop"
     )
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program
@@ -108,11 +116,13 @@ function Cli() {
   program
     .command("deprecate-create <target>")
     .description("Convert create to dashed fullwidth button")
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program
     .command("dialog-full-screen-app-wrapper <target>")
     .description("Wrap children of DialogFullScreen in AppWrapper")
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program
@@ -123,6 +133,7 @@ function Cli() {
   program
     .command("replace-flash-with-toast <target>")
     .description("Replaces deprecated Flash component with Toast component")
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program
@@ -135,6 +146,7 @@ function Cli() {
     .description(
       "Replace padding prop with p prop and change values on tile component"
     )
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program
@@ -160,6 +172,7 @@ Example
   named import:    npx carbon-codemod add-prop src carbon-react/lib/component propName propValue -i Component
     `
     )
+    .description("TypeScript conversion not yet supported")
     .action((target, importPath, prop, value, command) => {
       const { importName } = command;
       runTransform(target, command, program, {
@@ -253,6 +266,7 @@ Example
   named import:    npx carbon-codemod replace-prop-value src carbon-react/lib/component prop oldValue newValue -i Component
     `
     )
+    .description("TypeScript conversion not yet supported")
     .action((target, importPath, attribute, oldValue, newValue, command) => {
       const { importName } = command;
 
@@ -270,6 +284,7 @@ Example
     .description(
       "replaces deprecated collapse Pod prop with the Accordion Component"
     )
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program
@@ -277,6 +292,7 @@ Example
     .description(
       "removes deprecated description Pod prop and places it's value as part of the Pod content"
     )
+    .description("TypeScript conversion not yet supported")
     .action((target, command) => runTransform(target, command, program));
 
   program.on("command:*", function () {


### PR DESCRIPTION
Reverted tsx parser to default, as most of the codemods are not working with that parser.
Added info for non TypeScript compatible codemods.
Added the --typescript option to allow TypeScript project conversion.

### Proposed behaviour

<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Current behaviour

<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [x] Unit tests
- [x] Readme updated

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
