### PR TITLE
ci: replace semantic app with GHA to check PRs are semantically valid

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,0 @@
-allowMergeCommits: true
-titleAndCommits: true
-anyCommit: true

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -1,0 +1,18 @@
+name: Lint Commit Messages
+
+on: pull_request
+
+jobs:
+  commitlint:
+    # this will only run on non-forked PRs
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout_pr
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: lint_commits
+        uses: wagoid/commitlint-github-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Proposed behaviour

<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Remove `semantic.yml` config file as it is used by semantic app and that has been disabled
Add `semantic-commit-lint.yml` to handle checking all commits of non-forked PRs are semantically valid according to [coventional-commits](https://www.conventionalcommits.org/en/v1.0.0/) via a GitHub Action workflow


### Current behaviour

<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
No checks are currently carried out to ensure PRs are semantically valid

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [x] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Readme updated

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
I recommend this is tested in a separate repo which I will set up for whoever QAs this work:
- test that a valid commit message passes
- test invalid fails
- test multiple valid and one invalid fails
- test that forked PRs do not run workflow

Once the test session has been passed it will not require testing again when the workflow is added to carbon repo