### PR TITLE
ci: update semantic lint workflow to use npx script

### DIFF
--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -12,7 +12,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - id: setup_node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ">=14.16.0 14"
+      - id: install_dependencies
+        run: npm ci
       - id: lint_commits
-        uses: wagoid/commitlint-github-action@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/package-lock.json
+++ b/package-lock.json
@@ -5222,9 +5222,9 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "12.1.4",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-12.1.4.tgz",
-      "integrity": "sha512-ZIdzmdy4o4WyqywMEpprRCrehjCSQrHkaRTVZV411GyLigFQHlEBSJITAihLAWe88Qy/8SyoIe5uKvAsV5vRqQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-13.2.0.tgz",
+      "integrity": "sha512-7u7DdOiF+3qSdDlbQGfpvCH8DCQdLFvnI2+VucYmmV7E92iD6t9PBj+UjIoSQCaMAzYp27Vkall78AkcXBh6Xw==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "@commitlint/cli": "^13.1.0",
-    "@commitlint/config-conventional": "^12.1.4",
+    "@commitlint/config-conventional": "^13.1.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "babel-jest": "^27.0.2",


### PR DESCRIPTION
### Proposed behaviour

<!-- A clear and concise description of what changes this PR makes. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Replaces action used in workflow that lints commit messages with call to run the `npx commitlint` script from dependencies
Bumps dependency:   "@commitlint/config-conventional": "^13.1.0",

### Current behaviour

<!-- A clear and concise description of the behaviour before this change. -->
<!-- If applicable, add screenshots. You can paste these directly into GitHub. -->
Uses external action to lint commits

### Checklist

<!-- Each PR should include the following, if something is not applicable please use <del>tags to strikethrough. -->

- [ ] Release notes (Conventional Commits) <!-- https://www.conventionalcommits.org/en/v1.0.0-beta.4/ -->
- [ ] Unit tests
- [ ] Readme updated

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
